### PR TITLE
Feat: support infinity for integer ranges

### DIFF
--- a/src/Validator/Range.php
+++ b/src/Validator/Range.php
@@ -132,7 +132,7 @@ class Range extends Numeric
                 // Accept infinity as an integer
                 // Since gettype(INF) === TYPE_FLOAT
                 if ($value === INF || $value === -INF) {
-                    return true;
+                    break; // move to check if value is within range
                 }
                 $value = $value+0;
                 if(!is_int($value)) {

--- a/src/Validator/Range.php
+++ b/src/Validator/Range.php
@@ -116,6 +116,7 @@ class Range extends Numeric
      *
      * Validation will pass when $value number is bigger or equal than $min number and lower or equal than $max.
      * Not strict, considers any valid integer to be a valid float
+     * Considers infinity to be a valid integer
      *
      * @param  mixed $value
      * @return bool
@@ -128,6 +129,11 @@ class Range extends Numeric
 
         switch ($this->format) {
             case self::TYPE_INTEGER:
+                // Accept infinity as an integer
+                // Since gettype(INF) === TYPE_FLOAT
+                if ($value === INF || $value === -INF) {
+                    return true;
+                }
                 $value = $value+0;
                 if(!is_int($value)) {
                     return false;

--- a/tests/Validator/RangeTest.php
+++ b/tests/Validator/RangeTest.php
@@ -66,4 +66,17 @@ class RangeTest extends TestCase
         $this->assertEquals($this->rangeFloat->isArray(), false);
         $this->assertEquals($this->rangeFloat->getType(), \Utopia\Validator::TYPE_FLOAT);
     }
+
+    public function testInfinity()
+    {
+        $integer = new Range(5, INF, \Utopia\Validator::TYPE_INTEGER);
+        $float = new Range(-INF, 45.6, \Utopia\Validator::TYPE_FLOAT);
+
+        $this->assertEquals(true, $integer->isValid(25));
+        $this->assertEquals(false, $integer->isValid(3));
+        $this->assertEquals(true, $integer->isValid(INF));
+        $this->assertEquals(true, $float->isValid(32.1));
+        $this->assertEquals(false, $float->isValid(97.6));
+        $this->assertEquals(true, $float->isValid(-INF));
+    }
 }


### PR DESCRIPTION
Little needs to be added in in order to support use cases for upper bounds and lower bounds, since PHP has the special constant `INF`. However, validation logic fails when using infinity in integer ranges because:
```php
var_dump(gettype(INF));
// string(6) "double"
```

This PR handles the edge case where integer ranges use infinity.

**Testing**
This change includes appropriate unit tests