### PR TITLE
update integer and float validator tests to test loose condition

### DIFF
--- a/src/Validator/FloatValidator.php
+++ b/src/Validator/FloatValidator.php
@@ -24,6 +24,22 @@ use Utopia\Validator;
 class FloatValidator extends Validator
 {
     /**
+     * @var bool
+     */
+    protected $loose = false;
+
+    /**
+     * Pass true to accept float strings as valid float values
+     * This option is good for validating query string params.
+     *
+     * @param bool $loose
+     */
+    public function __construct(bool $loose = false)
+    {
+        $this->loose = $loose;
+    }
+
+    /**
      * Get Description
      *
      * Returns validator description
@@ -69,6 +85,12 @@ class FloatValidator extends Validator
      */
     public function isValid($value)
     {
+        if($this->loose) {
+            if(!\is_numeric($value)) {
+                return false;
+            }
+            $value = $value+0;
+        }
         if (!\is_float($value)) {
             return false;
         }

--- a/src/Validator/Integer.php
+++ b/src/Validator/Integer.php
@@ -13,7 +13,6 @@
 namespace Utopia\Validator;
 
 use Utopia\Validator;
-
 /**
  * Integer
  *
@@ -23,6 +22,22 @@ use Utopia\Validator;
  */
 class Integer extends Validator
 {
+    /**
+     * @var bool
+     */
+    protected $loose = false;
+
+    /**
+     * Pass true to accept integer strings as valid integer values
+     * This option is good for validating query string params.
+     *
+     * @param bool $loose
+     */
+    public function __construct(bool $loose = false)
+    {
+        $this->loose = $loose;
+    }
+
     /**
      * Get Description
      *
@@ -69,6 +84,12 @@ class Integer extends Validator
      */
     public function isValid($value)
     {
+        if($this->loose) {
+            if(!\is_numeric($value)) {
+                return false;
+            }
+            $value = $value+0;
+        }
         if (!\is_int($value)) {
             return false;
         }

--- a/tests/Validator/FloatValidatorTest.php
+++ b/tests/Validator/FloatValidatorTest.php
@@ -22,14 +22,21 @@ class FloatValidatorTest extends TestCase
      */
     protected $validator = null;
 
+    /**
+     * @var FloatValidator
+     */
+    protected $looseValidator = null;
+
     public function setUp():void
     {
         $this->validator = new FloatValidator();
+        $this->looseValidator = new FloatValidator(true);
     }
 
     public function tearDown():void
     {
         $this->validator = null;
+        $this->looseValidator = null;
     }
 
     public function testIsValid()
@@ -45,5 +52,17 @@ class FloatValidatorTest extends TestCase
         $this->assertEquals($this->validator->isValid('23'), false);
         $this->assertEquals($this->validator->getType(), \Utopia\Validator::TYPE_FLOAT);
         $this->assertEquals($this->validator->isArray(), false);
+
+        // Assertions Loose
+        $this->assertEquals($this->looseValidator->isValid(27.25), true);
+        $this->assertEquals($this->looseValidator->isValid('abc'), false);
+        $this->assertEquals($this->looseValidator->isValid(23), false);
+        $this->assertEquals($this->looseValidator->isValid(23.5), true);
+        $this->assertEquals($this->looseValidator->isValid(1e7), true);
+        $this->assertEquals($this->looseValidator->isValid(true), false);
+        $this->assertEquals($this->looseValidator->isValid('23.5'), true);
+        $this->assertEquals($this->looseValidator->isValid('23'), false);
+        $this->assertEquals($this->looseValidator->getType(), \Utopia\Validator::TYPE_FLOAT);
+        $this->assertEquals($this->looseValidator->isArray(), false);
     }
 }

--- a/tests/Validator/IntegerTest.php
+++ b/tests/Validator/IntegerTest.php
@@ -21,15 +21,22 @@ class IntegerTest extends TestCase
      * @var \Utopia\Validator\Integer
      */
     protected $validator = null;
+    
+    /**
+     * @var \Utopia\Validator\Integer
+     */
+    protected $looseValidator = null;
 
     public function setUp():void
     {
         $this->validator = new Integer();
+        $this->looseValidator = new Integer(true);
     }
 
     public function tearDown():void
     {
         $this->validator = null;
+        $this->looseValidator = null;
     }
 
     public function testIsValid()
@@ -44,5 +51,16 @@ class IntegerTest extends TestCase
         $this->assertEquals($this->validator->isValid(false), false);
         $this->assertEquals($this->validator->getType(), \Utopia\Validator::TYPE_INTEGER);
         $this->assertEquals($this->validator->isArray(), false);
+
+        // Assertions loose
+        $this->assertEquals($this->looseValidator->isValid(23), true);
+        $this->assertEquals($this->looseValidator->isValid('23'), true);
+        $this->assertEquals($this->looseValidator->isValid(23.5), false);
+        $this->assertEquals($this->looseValidator->isValid('23.5'), false);
+        $this->assertEquals($this->looseValidator->isValid(null), false);
+        $this->assertEquals($this->looseValidator->isValid(true), false);
+        $this->assertEquals($this->looseValidator->isValid(false), false);
+        $this->assertEquals($this->looseValidator->getType(), \Utopia\Validator::TYPE_INTEGER);
+        $this->assertEquals($this->looseValidator->isArray(), false);
     }
 }


### PR DESCRIPTION
Add loose validations to integer and float validators to accept integer and float strings respectively, useful for query params validation