### PR TITLE
Fix: whitelist validator should reject arrays of values

### DIFF
--- a/src/Validator/WhiteList.php
+++ b/src/Validator/WhiteList.php
@@ -91,7 +91,7 @@ class WhiteList extends Validator
      */
     public function isArray(): bool
     {
-        return true;
+        return false;
     }
 
     /**
@@ -116,6 +116,10 @@ class WhiteList extends Validator
      */
     public function isValid($value)
     {
+        if (\is_array($value)) {
+            return false;
+        }
+
         $value = ($this->strict) ? $value : \strtolower($value);
         
         if (!\in_array($value, $this->list, $this->strict)) {

--- a/tests/Validator/WhiteListTest.php
+++ b/tests/Validator/WhiteListTest.php
@@ -30,7 +30,7 @@ class WhiteListTest extends TestCase
         $this->assertEquals($whiteList->isValid(5), false);
         $this->assertEquals($whiteList->getList(), ['string1', 'string2', 3, 4]);
         $this->assertEquals($whiteList->getType(), \Utopia\Validator::TYPE_STRING); //string by default
-        $this->assertEquals($whiteList->isArray(), true);
+        $this->assertEquals($whiteList->isArray(), false);
         
         $whiteList = new WhiteList(['string1', 'string2', 3, 4], false);
 


### PR DESCRIPTION
This PR updates the whitelist validator to not accept arrays - even though the validator is constructed from arrays, values tested against the validator are not arrays.

**Testing** 

Unit tests have been updated to reflect this change.