### PR TITLE
Set cookie name to lowercase

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -347,7 +347,7 @@ class Response
     public function addCookie(string $name, string $value = null, int $expire = null, string $path = null, string $domain = null, bool $secure = null, bool $httponly = null, string $sameSite = null): self
     {
         $this->cookies[$name] = [
-            'name'		=> $name,
+            'name'		=> strtolower($name),
             'value'		=> $value,
             'expire'	=> $expire,
             'path' 		=> $path,


### PR DESCRIPTION
1. Cookie names are case insensitive
2. We have unique ids in our cookie names which are case insensitive in MariaDB
3. We are lowercasing cookie name while calling getCookie on utopia-swoole