### PR TITLE
Fix-cookie-name-case

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -346,8 +346,9 @@ class Response
      */
     public function addCookie(string $name, string $value = null, int $expire = null, string $path = null, string $domain = null, bool $secure = null, bool $httponly = null, string $sameSite = null): self
     {
+        $name = strtolower($name);
         $this->cookies[$name] = [
-            'name'		=> strtolower($name),
+            'name'		=> $name,
             'value'		=> $value,
             'expire'	=> $expire,
             'path' 		=> $path,

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -68,6 +68,11 @@ class ResponseTest extends TestCase
     {
         $result = $this->response->addCookie('name', 'value');
         $this->assertEquals($this->response, $result);
+
+        //test cookie case insensitive
+        $result = $this->response->addCookie('cookieName', 'cookieValue');
+        $result->getCookies()['cookiename']['name'] = 'cookiename';
+        $result->getCookies()['cookiename']['value'] = 'cookieValue';
     }
 
     public function testSend()


### PR DESCRIPTION
- Make cookie name case insensitive
- HTTP spec doesn't declare anything regarding case sensitivity and as headers themselves are case insensitive, this is mostly regarded as insensitive
- we are using unique IDs  in Appwrite in our cookie names which are case insensitive
- in Utopia swoole request getCookie we are already ignoring the case for cookie name https://github.com/utopia-php/swoole/blob/c9664cf6f9e4a671d72c8d47e33e5df3e8869914/src/Swoole/Request.php#L275