### PR TITLE
Limited assoc to 64kB

### DIFF
--- a/src/Validator/Assoc.php
+++ b/src/Validator/Assoc.php
@@ -73,6 +73,13 @@ class Assoc extends Validator
             return false;
         }
 
+        $jsonString = \json_encode($value);
+        $jsonStringSize = \strlen($jsonString);
+
+        if($jsonStringSize > 65535) {
+            return false;
+        }
+
         return \array_keys($value) !== \range(0, \count($value) - 1);
     }
 }

--- a/tests/Validator/AssocTest.php
+++ b/tests/Validator/AssocTest.php
@@ -42,6 +42,8 @@ class AssocTest extends TestCase
         $this->assertEquals(true, $this->assoc->isValid(["1" => 'a', "0" => 'b', "2" => 'c']));
         $this->assertEquals(true, $this->assoc->isValid(["a" => 'a', "b" => 'b', "c" => 'c']));
         $this->assertEquals(true, $this->assoc->isValid([]));
+        $this->assertEquals(true, $this->assoc->isValid(['value' => str_repeat("-", 62000)]));
+        $this->assertEquals(false, $this->assoc->isValid(['value' => str_repeat("-", 66000)]));
         $this->assertEquals($this->assoc->getType(), \Utopia\Validator::TYPE_ARRAY);
         $this->assertEquals($this->assoc->isArray(), true);
     }


### PR DESCRIPTION
This PR sets maximum limit for ASOC object to 64kB, so it can be stored as TEXT in database (255...65535).

Related PR: https://github.com/appwrite/appwrite/pull/2486