### PR TITLE
Run getParams after init

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -534,10 +534,10 @@ class App
      * Execute a given route with middlewares and error handling
      * 
      * @param Route $route
-     * @param array $args
+     * @param Request $request
      * @return self
      */
-    public function execute(Route $route, array $args = []): self
+    public function execute(Route $route, Request $request): self
     {
         $keys       = [];
         $arguments  = [];
@@ -568,6 +568,8 @@ class App
                     }
                 }
             }
+
+            $args = $request->getParams();
 
             foreach ($route->getParams() as $key => $param) { // Get value from route or request object
                 $arg = (isset($args[$key])) ? $args[$key] : $param['default'];
@@ -689,7 +691,7 @@ class App
         }
 
         if (null !== $route) {
-            return $this->execute($route, $request->getParams());
+            return $this->execute($route, $request);
         } elseif (self::REQUEST_METHOD_OPTIONS == $method) {
             try {
                 foreach ($groups as $group) {

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -14,6 +14,7 @@
 namespace Utopia;
 
 use PHPUnit\Framework\TestCase;
+use Utopia\Tests\UtopiaRequestTest;
 use Utopia\Validator\Text;
 
 App::setResource('rand', function () {return rand();});
@@ -98,7 +99,7 @@ class AppTest extends TestCase
         ;
 
         \ob_start();
-        $this->app->execute($route, []);
+        $this->app->execute($route, new Request());
         $result = \ob_get_contents();
         \ob_end_clean();
 
@@ -126,7 +127,7 @@ class AppTest extends TestCase
         ;
 
         \ob_start();
-        $this->app->execute($route, []);
+        $this->app->execute($route, new Request());
         $result = \ob_get_contents();
         \ob_end_clean();
         
@@ -134,7 +135,7 @@ class AppTest extends TestCase
         $route->setIsAlias(true);
         
         \ob_start();
-        $this->app->execute($route, []);
+        $this->app->execute($route, new Request());
         $result1 = \ob_get_contents();
         \ob_end_clean();
 
@@ -156,7 +157,9 @@ class AppTest extends TestCase
         ;
 
         \ob_start();
-        $this->app->execute($route, ['x' => 'param-x', 'y' => 'param-y']);
+        $request = new UtopiaRequestTest();
+        $request::_setParams(['x' => 'param-x', 'y' => 'param-y']);
+        $this->app->execute($route, $request);
         $result = \ob_get_contents();
         \ob_end_clean();
 
@@ -175,7 +178,9 @@ class AppTest extends TestCase
         ;
 
         \ob_start();
-        $this->app->execute($route, ['x' => 'param-x', 'y' => 'param-y']);
+        $request = new UtopiaRequestTest();
+        $request::_setParams(['x' => 'param-x', 'y' => 'param-y']);
+        $this->app->execute($route, $request);
         $result = \ob_get_contents();
         \ob_end_clean();
 
@@ -230,14 +235,18 @@ class AppTest extends TestCase
         ;
 
         \ob_start();
-        $this->app->execute($route, ['x' => 'param-x', 'y' => 'param-y']);
+        $request = new UtopiaRequestTest();
+        $request::_setParams(['x' => 'param-x', 'y' => 'param-y']);
+        $this->app->execute($route, $request);
         $result = \ob_get_contents();
         \ob_end_clean();
 
         $this->assertEquals('init-'.$resource.'-(init-api)-param-x-param-y-(shutdown-api)-shutdown', $result);
 
         \ob_start();
-        $this->app->execute($homepage, ['x' => 'param-x', 'y' => 'param-y']);
+        $request = new UtopiaRequestTest();
+        $request::_setParams(['x' => 'param-x', 'y' => 'param-y']);
+        $this->app->execute($homepage, $request);
         $result = \ob_get_contents();
         \ob_end_clean();
 
@@ -265,7 +274,7 @@ class AppTest extends TestCase
         ;
 
         \ob_start();
-        $this->app->execute($route, []);
+        $this->app->execute($route, new Request());
         $result = \ob_get_contents();
         \ob_end_clean();
 
@@ -283,7 +292,7 @@ class AppTest extends TestCase
         ;
 
         \ob_start();
-        $this->app->execute($route, []);
+        $this->app->execute($route, new Request());
         $result = \ob_get_contents();
         \ob_end_clean();
 

--- a/tests/UtopiaRequestTest.php
+++ b/tests/UtopiaRequestTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Utopia\Tests;
+
+use Utopia\Request as UtopiaRequest;
+
+class UtopiaRequestTest extends UtopiaRequest
+{
+    /**
+     * @var array
+     */
+    private static $params = null;
+
+    /**
+     * Get Param
+     *
+     * Get param by current method name
+     *
+     * @param string $key
+     * @param mixed $default
+     * @return mixed
+     */
+    public function getParam(string $key, $default = null): mixed
+    {
+        if($this::_hasParams() && \in_array($key, $this::_getParams())) {
+            return $this::_getParams()[$key];
+        }
+
+        return parent::getParam($key, $default);
+    }
+
+    /**
+     * Get Params
+     *
+     * Get all params of current method
+     *
+     * @return array
+     */
+    public function getParams(): array
+    {
+        $paramsArray = [];
+
+        if($this::_hasParams()) {
+            $paramsArray = $this::_getParams();
+        }
+
+        return \array_merge($paramsArray, parent::getParams());
+    }
+
+
+    /**
+     * Function to set a response filter
+     *
+     * @param ?array $params
+     *
+     * @return void
+     */
+    public static function _setParams(?array $params)
+    {
+        self::$params = $params;
+    }
+
+    /**
+     * Return the currently set filter
+     *
+     * @return ?array
+     */
+    public static function _getParams(): ?array
+    {
+        return self::$params;
+    }
+
+    /**
+     * Check if a filter has been set
+     *
+     * @return bool
+     */
+    public static function _hasParams(): bool
+    {
+        return self::$params != null;
+    }
+}


### PR DESCRIPTION
This allows running code that required `->match()` before Utopia gets parameters. This is important, because you cannot write such a code before running `->run()`, because at the top of `run` we do some sorting of `$routes`, and for that to work properly, we need to run `->match()` after running this sorting.

## Opened questions

Not sure how to re-write tests. A lot of tests send empty args array, some send specific args that we test. I also removed the default value that can cause some troubles.