### PR TITLE
Fix: Cookies expiry

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -574,6 +574,11 @@ class Response
      */
     protected function sendCookie(string $name, string $value, array $options): void
     {
+        // Use proper PHP keyword name
+        $options['expires'] = $options['expire'];
+        unset($options['expire']);
+
+        // Set the cookie
         \setcookie($name, $value, $options);
     }
 
@@ -588,7 +593,7 @@ class Response
     {
         foreach ($this->cookies as $cookie) {
             $this->sendCookie($cookie['name'], $cookie['value'], [
-                'expires'	=> $cookie['expire'],
+                'expire'	=> $cookie['expire'],
                 'path' 		=> $cookie['path'],
                 'domain' 	=> $cookie['domain'],
                 'secure' 	=> $cookie['secure'],


### PR DESCRIPTION
## Problem

In Appwrite, cookies were set with an expiry of the session: https://github.com/appwrite/appwrite/issues/3080

![CleanShot 2022-04-12 at 15 03 20](https://user-images.githubusercontent.com/19310830/162968734-2259e3da-0f3d-4cb2-896b-d6151f2bef42.png)

![CleanShot 2022-04-12 at 15 03 46](https://user-images.githubusercontent.com/19310830/162968737-64160168-eb55-497e-bb5d-4fdac9a7440a.png)

## Investigation

There was a miss-match between Framework and Swoole, one naming it `expire`, one `expires`:

Swoole: https://github.com/utopia-php/swoole/blob/master/src/Swoole/Response.php#L91
PHP: https://github.com/utopia-php/framework/blob/master/src/Response.php#L591

The reason for this is because PHP `setcookie()` expects `expires`, so it was probably a quick patch from earlier.

## Solution

I decided to stick with `expire`, as this keyword is used all around the Framework library, as well as in Swoole.

I added a step before using PHP setcookie, to rename the parameter to what is expected by this built-in PHP method.

Expiry should now work properly.

## Tests

I did manual QA in Appwrite using this branch, ensuring the expiry date is now present, and it worked.

![CleanShot 2022-04-12 at 14 58 17](https://user-images.githubusercontent.com/19310830/162967892-1d47f31f-8754-4a46-b470-00d0d5be3f6f.png)

