### PR TITLE
Feat allow mutations

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -495,6 +495,28 @@ class Request
     }
 
     /**
+     * Set GET parameters
+     *
+     * @param array $params
+     * @return void
+     */
+    public function setGet(array $params)
+    {
+        $_GET = $params;
+    }
+
+    /**
+     * Set POST parameters
+     *
+     * @param array $params
+     * @return void
+     */
+    public function setPost(array $params)
+    {
+        $_POST = $params;
+    }
+
+    /**
      * Generate input
      *
      * Generate PHP input stream and parse it as an array in order to handle different content type of requests

--- a/src/Request.php
+++ b/src/Request.php
@@ -29,6 +29,11 @@ class Request
     const METHOD_CONNECT = 'CONNECT';
 
     /**
+     * @var string
+     */
+    private $raw = '';
+
+    /**
      * Container for php://input parsed stream
      *
      * @var array|null
@@ -108,6 +113,18 @@ class Request
         $payload = $this->generateInput();
 
         return $payload[$key] ?? $default;
+    }
+
+    /**
+     * Get raw payload
+     *
+     * Method for getting the HTTP request payload as a raw string.
+     *
+     * @return string
+     */
+    public function getRawPayload(): string
+    {
+        return $this->raw;
     }
 
     /**
@@ -533,11 +550,12 @@ class Request
             $length         = (empty($length)) ? \strlen($contentType) : $length;
             $contentType    = \substr($contentType, 0, $length);
 
+            $this->raw = \file_get_contents('php://input');
+
             switch ($contentType) {
                 case 'application/json':
-                    $this->payload = \json_decode(\file_get_contents('php://input'), true);
+                    $this->payload = \json_decode($this->raw, true);
                     break;
-
                 default:
                     $this->payload = $_POST;
                     break;

--- a/src/Request.php
+++ b/src/Request.php
@@ -225,6 +225,21 @@ class Request
     }
 
     /**
+     * Get Path
+     *
+     * Return HTTP request path
+     *
+     * @param string $uri
+     * @return self
+     */
+    public function setURI(string $uri): self
+    {
+        $this->setServer('REQUEST_URI', $uri);
+
+        return $this;
+    }
+
+    /**
      * Get files
      *
      * Method for querying upload files data. If $key is not found empty array will be returned.

--- a/src/Request.php
+++ b/src/Request.php
@@ -124,6 +124,13 @@ class Request
         return $_SERVER[$key] ?? $default;
     }
 
+    public function setServer(string $key, string $value): self
+    {
+        $_SERVER[$key] = $value;
+
+        return $this;
+    }
+
     /**
      * Get IP
      *
@@ -188,6 +195,21 @@ class Request
     public function getMethod(): string
     {
         return $this->getServer('REQUEST_METHOD') ?? 'UNKNOWN';
+    }
+
+    /**
+     * Set Method
+     *
+     * Set HTTP request method
+     *
+     * @param string $method
+     * @return self
+     */
+    public function setMethod(string $method): self
+    {
+        $this->setServer('REQUEST_METHOD', $method);
+
+        return $this;
     }
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -339,6 +339,35 @@ class Request
     }
 
     /**
+     * Set header
+     *
+     * Method for setting HTTP header parameters.
+     *
+     * @param string $key
+     * @param string $value
+     * @return void
+     */
+    public function setHeader(string $key, string $value): void
+    {
+        $this->headers[$key] = $value;
+    }
+
+    /**
+     * Remvoe header
+     *
+     * Method for removing HTTP header parameters.
+     *
+     * @param string $key
+     * @return void
+     */
+    public function removeHeader(string $key): void
+    {
+        if (isset($this->headers[$key])) {
+            unset($this->headers[$key]);
+        }
+    }
+
+    /**
      * Get Request Size
      *
      * Returns request size in bytes

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -39,9 +39,40 @@ class RequestTest extends TestCase
         $this->assertEquals('value2', $this->request->getHeader('custom-new'));
     }
 
+    public function testCanAddHeaders()
+    {
+        $this->request->addHeader('custom', 'value1');
+        $this->request->addHeader('custom-new', 'value2');
+
+        $this->assertEquals('value1', $this->request->getHeader('custom'));
+        $this->assertEquals('value2', $this->request->getHeader('custom-new'));
+    }
+
+    public function testCanRemoveHeaders()
+    {
+        $this->request->addHeader('custom', 'value1');
+        $this->request->addHeader('custom-new', 'value2');
+
+        $this->assertEquals('value1', $this->request->getHeader('custom'));
+        $this->assertEquals('value2', $this->request->getHeader('custom-new'));
+
+        $this->request->removeHeader('custom');
+
+        $this->assertEquals(null, $this->request->getHeader('custom'));
+        $this->assertEquals('value2', $this->request->getHeader('custom-new'));
+    }
+
     public function testCanGetQueryParameter()
     {
         $_GET['key'] = 'value';
+
+        $this->assertEquals($this->request->getQuery('key'), 'value');
+        $this->assertEquals($this->request->getQuery('unknown', 'test'), 'test');
+    }
+
+    public function testCanSetQueryString()
+    {
+        $this->request->setQueryString(['key' => 'value']);
 
         $this->assertEquals($this->request->getQuery('key'), 'value');
         $this->assertEquals($this->request->getQuery('unknown', 'test'), 'test');
@@ -52,9 +83,30 @@ class RequestTest extends TestCase
         $this->assertEquals($this->request->getPayload('unknown', 'test'), 'test');
     }
 
+    public function testCanSetPayload()
+    {
+        $this->request->setPayload(['key' => 'value']);
+
+        $this->assertEquals($this->request->getPayload('key'), 'value');
+        $this->assertEquals($this->request->getPayload('unknown', 'test'), 'test');
+    }
+
+    public function testCanGetRawPayload()
+    {
+        $this->assertEquals($this->request->getRawPayload(), '');
+    }
+
     public function testCanGetServer()
     {
         $_SERVER['key'] = 'value';
+
+        $this->assertEquals($this->request->getServer('key'), 'value');
+        $this->assertEquals($this->request->getServer('unknown', 'test'), 'test');
+    }
+
+    public function testCanSetServer()
+    {
+        $this->request->setServer('key', 'value');
 
         $this->assertEquals($this->request->getServer('key'), 'value');
         $this->assertEquals($this->request->getServer('unknown', 'test'), 'test');
@@ -100,6 +152,13 @@ class RequestTest extends TestCase
         $_SERVER['REQUEST_URI'] = '/index.html';
 
         $this->assertEquals('/index.html', $this->request->getURI());
+    }
+
+    public function testCanSetUri()
+    {
+        $this->request->setURI('/page.html');
+
+        $this->assertEquals('/page.html', $this->request->getURI());
     }
 
     public function testCanGetPort()


### PR DESCRIPTION
## What's changed

Adds getters/setters (to avoid directly mutating the underlying structure in Appwrite GraphQL)

- Allow setting request method
- Allow setting request URI
- Allow setting and removing headers
- Allow setting $_GET and $_POST
- Allow getting request raw payload

## Related PRs

https://github.com/utopia-php/swoole/pull/24
https://github.com/appwrite/appwrite/pull/974

