### PR TITLE
Add support for multiple aliases

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -28,18 +28,11 @@ class Route extends Hook
     protected string $path = '';
 
     /**
-     * Alias path
-     *
-     * @var string
-     */
-    protected string $aliasPath = '';
-
-    /**
-     * Alias Params
+     * Array of aliases where key is the path and value is an array of params
      *
      * @var array
      */
-    protected array $aliasParams = [];
+    protected array $aliases = [];
 
     /**
      * Is Alias Route?
@@ -73,7 +66,8 @@ class Route extends Hook
         $this->path($path);
         $this->method = $method;
         $this->order = self::$counter;
-        $this->action = function (): void {};
+        $this->action = function (): void {
+        };
     }
 
     /**
@@ -98,8 +92,7 @@ class Route extends Hook
      */
     public function alias(string $path, array $params = []): static
     {
-        $this->aliasPath = $path;
-        $this->aliasParams = $params;
+        $this->aliases[$path] = $params;
 
         return $this;
     }
@@ -173,23 +166,45 @@ class Route extends Hook
     }
 
     /**
+     * Get Aliases
+     *
+     * For backwards compatibility, returns the first alias path
+     * 
+     * @return array
+     */
+    public function getAliases(): array
+    {
+        return $this->aliases;
+    }
+
+    /**
      * Get Alias path
      *
+     * For backwards compatibility, returns the first alias path
+     * 
      * @return string
      */
     public function getAliasPath(): string
     {
-        return $this->aliasPath;
+        $paths = array_keys($this->aliases);
+        return array_pop($paths) ?? '';
     }
 
     /**
      * Get Alias Params
      *
+     * For backwards compatibility, returns the first alias params if no path passed
+     * 
      * @return array
      */
-    public function getAliasParams(): array
+    public function getAliasParams(string $path = null): array
     {
-        return $this->aliasParams;
+        if ($path === null) {
+            $params = array_values($this->aliases);
+            return array_pop($params) ?? [];
+        }
+
+        return $this->aliases[$path];
     }
 
     /**

--- a/src/Route.php
+++ b/src/Route.php
@@ -28,6 +28,13 @@ class Route extends Hook
     protected string $path = '';
 
     /**
+     * Alias path
+     *
+     * @var null|string
+     */
+    protected ?string $aliasPath = null;
+
+    /**
      * Array of aliases where key is the path and value is an array of params
      *
      * @var array
@@ -168,7 +175,7 @@ class Route extends Hook
     /**
      * Get Aliases
      *
-     * For backwards compatibility, returns the first alias path
+     * Returns an array where the keys are paths and values are params
      * 
      * @return array
      */
@@ -186,8 +193,28 @@ class Route extends Hook
      */
     public function getAliasPath(): string
     {
+        if ($this->aliasPath !== null) {
+            return $this->aliasPath;
+        }
+
         $paths = array_keys($this->aliases);
-        return array_pop($paths) ?? '';
+        if (count($paths) === 0) {
+            return '';
+        }
+        return $paths[0];
+    }
+
+    /**
+     * Set Alias path
+     *
+     * For backwards compatibility, returns the first alias path
+     * 
+     * @return void
+     */
+    public function setAliasPath(?string $path): void
+    {
+        $this->aliasPath = $path;
+        $this->setIsAlias($path !== null);
     }
 
     /**
@@ -201,7 +228,10 @@ class Route extends Hook
     {
         if ($path === null) {
             $params = array_values($this->aliases);
-            return array_pop($params) ?? [];
+            if (count($params) === 0) {
+                return [];
+            }
+            return $params[0];
         }
 
         return $this->aliases[$path];

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -397,35 +397,43 @@ class AppTest extends TestCase
 
     public function providerRouteMatching(): array
     {
-        $route1 = App::get('/path1');
-        $route2 = App::get('/path2');
-        $route3 = App::post('/path1');
-        $route4 = App::put('/path1');
-        $route5 = App::patch('/path1');
-        $route6 = App::delete('/path1');
-        $route7 = App::get('/a/b/c');
-        $route8 = App::get('/a/b');
-        $route9 = App::get('/a');
-
         return [
-            'GET request' => [$route1, App::REQUEST_METHOD_GET, '/path1'],
-            'GET request on different route' => [$route2, App::REQUEST_METHOD_GET, '/path2'],
-            'POST request' => [$route3, App::REQUEST_METHOD_POST, '/path1'],
-            'PUT request' => [$route4, App::REQUEST_METHOD_PUT, '/path1'],
-            'PATCH request' => [$route5, App::REQUEST_METHOD_PATCH, '/path1'],
-            'DELETE request' => [$route6, App::REQUEST_METHOD_DELETE, '/path1'],
+            'GET request' => [App::REQUEST_METHOD_GET, '/path1'],
+            'GET request on different route' => [App::REQUEST_METHOD_GET, '/path2'],
+            'POST request' => [App::REQUEST_METHOD_POST, '/path1'],
+            'PUT request' => [App::REQUEST_METHOD_PUT, '/path1'],
+            'PATCH request' => [App::REQUEST_METHOD_PATCH, '/path1'],
+            'DELETE request' => [App::REQUEST_METHOD_DELETE, '/path1'],
             // "/a/b/c" needs to be first
-            '3 separators' => [$route7, App::REQUEST_METHOD_GET, '/a/b/c'],
-            '2 separators' => [$route8, App::REQUEST_METHOD_GET, '/a/b'],
-            '1 separators' => [$route9, App::REQUEST_METHOD_GET, '/a']
+            '3 separators' => [App::REQUEST_METHOD_GET, '/a/b/c'],
+            '2 separators' => [App::REQUEST_METHOD_GET, '/a/b'],
+            '1 separators' => [App::REQUEST_METHOD_GET, '/a']
         ];
     }
 
     /**
      * @dataProvider providerRouteMatching
      */
-    public function testCanMatchRoute(Route $expected, string $method, string $path): void
+    public function testCanMatchRoute(string $method, string $path): void
     {
+        switch ($method) {
+            case App::REQUEST_METHOD_GET:
+                $expected = App::get($path);
+                break;
+            case App::REQUEST_METHOD_POST:
+                $expected = App::post($path);
+                break;
+            case App::REQUEST_METHOD_PUT:
+                $expected = App::put($path);
+                break;
+            case App::REQUEST_METHOD_PATCH:
+                $expected = App::patch($path);
+                break;
+            case App::REQUEST_METHOD_DELETE:
+                $expected = App::delete($path);
+                break;
+        }
+
         $_SERVER['REQUEST_METHOD'] = $method;
         $_SERVER['REQUEST_URI'] = $path;
 
@@ -514,5 +522,50 @@ class AppTest extends TestCase
         \ob_end_clean();
 
         $this->assertStringNotContainsString('HELLO', $result1);
+    }
+
+    public function providerAliases(): array
+    {
+        return [
+            '/real/:param1' => ['/real/p1', 'p1'],
+            '/alias' => ['/alias', 'default'],
+            '/another/:param1' => ['/another/a', 'a'],
+            '/param2' => ['/param2', 'param2']
+        ];
+    }
+
+    /**
+     * @dataProvider providerAliases
+     */
+    public function testMultipleAliases(string $path, string $expected): void
+    {
+        App::get('/real/:param1')
+            ->alias('/alias', [
+                "param1" => "default",
+            ])
+            ->alias('/another/:param1')
+            ->alias('/param2', [
+                "param1" => "param2",
+            ])
+            ->param('param1', '', new Text(100), 'a param', false)
+            ->inject('response')
+            ->action(function ($param1, $response) {
+                echo $param1;
+            });
+
+        $routes = App::getRoutes();
+        $this->assertContains('/real/:param1', array_keys($routes[App::REQUEST_METHOD_GET]));
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        $_SERVER['REQUEST_URI'] = $path;
+        \ob_start();
+        $this->app->run(new Request(), new Response());
+        $result = \ob_get_contents();
+        \ob_end_clean();
+
+        var_dump($result);
+
+        $this->assertEquals($expected, $result);
     }
 }

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -42,6 +42,35 @@ class RouteTest extends TestCase
         $this->assertEquals($params, $this->route->getAliasParams());
     }
 
+    public function testCanSetAndGetAliases()
+    {
+        $this->assertEquals('', $this->route->getAliasPath());
+        $this->assertEquals([], $this->route->getAliasParams());
+
+        $path1Params = [
+            'pathId' => 'hello'
+        ];
+        $this->route->alias('/path1', $path1Params);
+
+        $path2Params = [
+            'anotherPathId' => 'world'
+        ];
+        $this->route->alias('/path2', $path2Params);
+
+        $aliases = $this->route->getAliases();
+
+        $this->assertEquals(
+            [
+                '/path1' => $path1Params,
+                '/path2' => $path2Params,
+            ],
+            $aliases
+        );
+
+        $this->assertEquals($path1Params, $this->route->getAliasParams('/path1'));
+        $this->assertEquals($path2Params, $this->route->getAliasParams('/path2'));
+    }
+
     public function testCanSetAndGetDescription()
     {
         $this->assertEquals('', $this->route->getDesc());

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -67,6 +67,8 @@ class RouteTest extends TestCase
             $aliases
         );
 
+        $this->assertEquals('/path1', $this->route->getAliasPath());
+        $this->assertEquals($path1Params, $this->route->getAliasParams());
         $this->assertEquals($path1Params, $this->route->getAliasParams('/path1'));
         $this->assertEquals($path2Params, $this->route->getAliasParams('/path2'));
     }


### PR DESCRIPTION
Previously, it was only possible to set 1 alias on a route. This PR updates Route to support multiple aliases and App to handle requests against all aliases.