### PR TITLE
Update error handler to include message from previous error

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -590,7 +590,7 @@ class App
                         $arguments = $this->getArguments($error, $values, $request->getParams());
                         \call_user_func_array($error->getAction(), $arguments);
                     } catch (\Throwable $e) {
-                        throw new Exception('Error handler had an error', 0, $e);
+                        throw new Exception('Error handler had an error: ' . $e->getMessage(), 500, $e);
                     }
                 }
             }


### PR DESCRIPTION
Before, the logs provided very little context about what really happened:

```
appwrite  | [Error] Type: Utopia\Exception
appwrite  | [Error] Message: Error handler had an error
appwrite  | [Error] File: /usr/src/code/vendor/utopia-php/framework/src/App.php
appwrite  | [Error] Line: 610
```

After this, at least, the message will include the underlying error:

```
appwrite  | [Error] Type: Utopia\Exception
appwrite  | [Error] Message: Error handler had an error: Can't find FULLTEXT index matching the column list
appwrite  | [Error] File: /usr/src/code/vendor/utopia-php/framework/src/App.php
appwrite  | [Error] Line: 610
```

Related:

* https://github.com/appwrite/appwrite/issues/4535