### PR TITLE
fix: race condition for request/response resources

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -680,7 +680,7 @@ class App
     public function run(Request $request, Response $response): static
     {
         $this->resources['request'] = $request;
-        $this->resources['response'] = $request;
+        $this->resources['response'] = $response;
 
         self::setResource('request', function () use ($request) {
             return $request;

--- a/src/App.php
+++ b/src/App.php
@@ -679,6 +679,9 @@ class App
      */
     public function run(Request $request, Response $response): static
     {
+        $this->resources['request'] = $request;
+        $this->resources['response'] = $request;
+
         self::setResource('request', function () use ($request) {
             return $request;
         });
@@ -686,9 +689,6 @@ class App
         self::setResource('response', function () use ($response) {
             return $response;
         });
-
-        $this->resources['request'] = $request;
-        $this->resources['response'] = $request;
 
         /*
          * Re-order array

--- a/src/App.php
+++ b/src/App.php
@@ -687,6 +687,9 @@ class App
             return $response;
         });
 
+        $this->resources['request'] = $request;
+        $this->resources['response'] = $request;
+
         /*
          * Re-order array
          *


### PR DESCRIPTION
On multithreaded environments, the `request` and `response` set in `run(...)` can run into a race condition when the static callback is called after a different request has overwritten its callback.

This forces the resource to be set initially.