### PR TITLE
Feat: Improve hostname validator

### DIFF
--- a/src/Validator/Hostname.php
+++ b/src/Validator/Hostname.php
@@ -96,32 +96,14 @@ class Hostname extends Validator
             }
 
             // If wildcard symbol used
-            if (\str_contains($allowedHostname, '*')) {
-                // Split hostnames into sections (subdomains)
-                $allowedSections = \explode('.', $allowedHostname);
-                $valueSections = \explode('.', $value);
+            if(\str_starts_with($allowedHostname, '*')) {
+                // Remove starting * symbol before comparing
+                $allowedHostname = substr($allowedHostname, 1);
 
-                // Only if amount of sections matches
-                if (\count($allowedSections) === \count($valueSections)) {
-                    $matchesAmount = 0;
-
-                    // Loop through all sections
-                    for ($sectionIndex = 0; $sectionIndex < \count($allowedSections); $sectionIndex++) {
-                        $allowedSection = $allowedSections[$sectionIndex];
-
-                        // If section matches, or wildcard symbol is used, increment match count
-                        if ($allowedSection === '*' || $allowedSection === $valueSections[$sectionIndex]) {
-                            $matchesAmount++;
-                        } else {
-                            // If one fails, the whole check always fails; we can skip iterations
-                            break;
-                        }
-                    }
-
-                    // If every section matched; allow
-                    if ($matchesAmount === \count($allowedSections)) {
-                        return true;
-                    }
+                // If rest of hostname match; allow
+                // Notice allowedHostname still includes starting dot. Root domain is NOT allowed by wildcard.
+                if(\str_ends_with($value, $allowedHostname)) {
+                    return true;
                 }
             }
         }

--- a/tests/Validator/HostnameTest.php
+++ b/tests/Validator/HostnameTest.php
@@ -55,7 +55,6 @@ class HostnameTest extends TestCase
             'myweb.vercel.app',
             'myweb.com',
             '*.myapp.com',
-            '*.*.myrepo.com',
         ]);
 
         $this->assertTrue($validator->isValid('myweb.vercel.app'));
@@ -73,15 +72,9 @@ class HostnameTest extends TestCase
         $this->assertTrue($validator->isValid('project2.myapp.com'));
         $this->assertTrue($validator->isValid('project-with-dash.myapp.com'));
         $this->assertTrue($validator->isValid('anything.myapp.com'));
+        $this->assertTrue($validator->isValid('commit.anything.myapp.com'));
         $this->assertFalse($validator->isValid('anything.myapp.eu'));
-        $this->assertFalse($validator->isValid('commit.anything.myapp.com'));
-
-        $this->assertTrue($validator->isValid('commit1.project1.myrepo.com'));
-        $this->assertTrue($validator->isValid('commit2.project3.myrepo.com'));
-        $this->assertTrue($validator->isValid('commit-with-dash.project-with-dash.myrepo.com'));
-        $this->assertFalse($validator->isValid('myrepo.com'));
-        $this->assertFalse($validator->isValid('project1.myrepo.com'));
-        $this->assertFalse($validator->isValid('line1.commit1.project1.myrepo.com'));
+        $this->assertFalse($validator->isValid('myapp.com'));
 
         $validator = new Hostname(['localhost']);
         $this->assertTrue($validator->isValid('localhost'));
@@ -93,9 +86,15 @@ class HostnameTest extends TestCase
         $this->assertTrue($validator->isValid('*'));
 
         $validator = new Hostname(['netlify.*']);
-        $this->assertTrue($validator->isValid('netlify.com'));
-        $this->assertTrue($validator->isValid('netlify.eu'));
-        $this->assertTrue($validator->isValid('netlify.app'));
+        $this->assertFalse($validator->isValid('netlify.com'));
+        $this->assertFalse($validator->isValid('netlify.eu'));
+        $this->assertFalse($validator->isValid('netlify.app'));
+
+        $validator = new Hostname(['*.*.app.io']);
+        $this->assertFalse($validator->isValid('app.io'));
+        $this->assertFalse($validator->isValid('project.app.io'));
+        $this->assertFalse($validator->isValid('commit.project.app.io'));
+        $this->assertFalse($validator->isValid('api.commit.project.app.io'));
 
         $validator = new Hostname(['*']);
         $this->assertTrue($validator->isValid('*'));


### PR DESCRIPTION
Problems with previous solution:
- Too complex
- Allowed multiple wildcards like `*.*.gitpod.io` which is not allowed by standard
- Wildcard only allowed one level of subdomain, not all of them
- Wildcard was allowed in middle of domain like `api.*.com` and `myapp.*`. Again, not part of standard

- [x] New logic implemented
- [x] Tests updated