### PR TITLE
Fix: boolean validator

### DIFF
--- a/src/Validator/Boolean.php
+++ b/src/Validator/Boolean.php
@@ -77,14 +77,6 @@ class Boolean extends Validator
             return true;
         }
 
-        if ($this->loose && ($value === '1' || $value === '0')) { // Accept numeric strings
-            return true;
-        }
-
-        if ($this->loose && ($value === 1 || $value === 0)) { // Accept integers
-            return true;
-        }
-
         if (\is_bool($value)) {
             return true;
         }

--- a/tests/Validator/BooleanTest.php
+++ b/tests/Validator/BooleanTest.php
@@ -33,10 +33,10 @@ class BooleanTest extends TestCase
         $this->assertTrue($boolean->isValid(false));
         $this->assertTrue($boolean->isValid('false'));
         $this->assertTrue($boolean->isValid('true'));
-        $this->assertTrue($boolean->isValid('0'));
-        $this->assertTrue($boolean->isValid('1'));
-        $this->assertTrue($boolean->isValid(0));
-        $this->assertTrue($boolean->isValid(1));
+        $this->assertFalse($boolean->isValid('0'));
+        $this->assertFalse($boolean->isValid('1'));
+        $this->assertFalse($boolean->isValid(0));
+        $this->assertFalse($boolean->isValid(1));
         $this->assertFalse($boolean->isValid(['string', 'string']));
         $this->assertFalse($boolean->isValid('string'));
         $this->assertFalse($boolean->isValid(1.2));


### PR DESCRIPTION
Disallow 0, 1, '0', '1' from boolean loose validator. This is not expected by HTTP communication and we should not support it.

- [x] Tests updated