### PR TITLE
Fix route mismatch against shorter paths when params are missing

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -510,6 +510,11 @@ class App
                 continue;
             }
 
+            // Check the paths have the same amount of segments
+            if (\substr_count($routeUrl, '/') !== \substr_count($url, '/')) {
+                continue;
+            }
+
             \array_shift($this->matches);
             $this->route = $route;
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -404,10 +404,9 @@ class AppTest extends TestCase
             'PUT request' => [App::REQUEST_METHOD_PUT, '/path1'],
             'PATCH request' => [App::REQUEST_METHOD_PATCH, '/path1'],
             'DELETE request' => [App::REQUEST_METHOD_DELETE, '/path1'],
-            // "/a/b/c" needs to be first
-            '3 separators' => [App::REQUEST_METHOD_GET, '/a/b/c'],
+            '1 separators' => [App::REQUEST_METHOD_GET, '/a/'],
             '2 separators' => [App::REQUEST_METHOD_GET, '/a/b'],
-            '1 separators' => [App::REQUEST_METHOD_GET, '/a'],
+            '3 separators' => [App::REQUEST_METHOD_GET, '/a/b/c'],
         ];
     }
 
@@ -441,6 +440,36 @@ class AppTest extends TestCase
 
         $this->assertEquals($expected, $this->app->match(new Request()));
         $this->assertEquals($expected, $this->app->getRoute());
+    }
+
+    public function testNoMismatchRoute(): void
+    {
+        $requests = [
+            [
+                'path' => '/d/:id',
+                'url' => '/d/'
+            ],
+            [
+                'path' => '/d/:id/e/:id2',
+                'url' => '/d/123/e/'
+            ],
+            [
+                'path' => '/d/:id/e/:id2/f/:id3',
+                'url' => '/d/123/e/456/f/'
+            ],
+        ];
+
+        foreach ($requests as $request) {
+            App::get($request['path']);
+
+            $_SERVER['REQUEST_METHOD'] = App::REQUEST_METHOD_GET;
+            $_SERVER['REQUEST_URI'] = $request['url'];
+
+            $route = $this->app->match(new Request(), fresh: true);
+
+            $this->assertEquals(null, $route);
+            $this->assertEquals(null, $this->app->getRoute());
+        }
     }
 
     public function testCanMatchFreshRoute(): void


### PR DESCRIPTION
## What's Changed

- Added a check to ensure that the matched URL has the same amount of segments (separated by `/`) as the route. This ensures that a URL will not match an incorrect route if parameters are missing.

## Tests

- Added new tests to ensure correct matching