### PR TITLE
Fix: Swoole coroutine http server

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -232,16 +232,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.13.1",
+            "version": "v1.13.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "22f204242d68095b3ba7dab5d3ef0240454a4652"
+                "reference": "93b2d0d49719bc6e444ba21cd4dbbccec935413d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/22f204242d68095b3ba7dab5d3ef0240454a4652",
-                "reference": "22f204242d68095b3ba7dab5d3ef0240454a4652",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/93b2d0d49719bc6e444ba21cd4dbbccec935413d",
+                "reference": "93b2d0d49719bc6e444ba21cd4dbbccec935413d",
                 "shasum": ""
             },
             "require": {
@@ -252,13 +252,13 @@
                 "php": "^8.1.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.21.1",
-                "illuminate/view": "^10.5.1",
+                "friendsofphp/php-cs-fixer": "^3.34.1",
+                "illuminate/view": "^10.23.1",
                 "laravel-zero/framework": "^10.1.2",
-                "mockery/mockery": "^1.5.1",
-                "nunomaduro/larastan": "^2.5.1",
+                "mockery/mockery": "^1.6.6",
+                "nunomaduro/larastan": "^2.6.4",
                 "nunomaduro/termwind": "^1.15.1",
-                "pestphp/pest": "^2.4.0"
+                "pestphp/pest": "^2.18.2"
             },
             "bin": [
                 "builds/pint"
@@ -294,7 +294,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2023-09-06T11:03:34+00:00"
+            "time": "2023-10-10T15:39:09+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -716,16 +716,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.33",
+            "version": "1.10.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "03b1cf9f814ba0863c4e9affea49a4d1ed9a2ed1"
+                "reference": "5302bb402c57f00fb3c2c015bac86e0827e4b691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/03b1cf9f814ba0863c4e9affea49a4d1ed9a2ed1",
-                "reference": "03b1cf9f814ba0863c4e9affea49a4d1ed9a2ed1",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/5302bb402c57f00fb3c2c015bac86e0827e4b691",
+                "reference": "5302bb402c57f00fb3c2c015bac86e0827e4b691",
                 "shasum": ""
             },
             "require": {
@@ -774,20 +774,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-04T12:20:53+00:00"
+            "time": "2023-10-06T14:19:14+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.27",
+            "version": "9.2.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "b0a88255cb70d52653d80c890bd7f38740ea50d1"
+                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/b0a88255cb70d52653d80c890bd7f38740ea50d1",
-                "reference": "b0a88255cb70d52653d80c890bd7f38740ea50d1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6a3a87ac2bbe33b25042753df8195ba4aa534c76",
+                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76",
                 "shasum": ""
             },
             "require": {
@@ -844,7 +844,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.27"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.29"
             },
             "funding": [
                 {
@@ -852,7 +852,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-07-26T13:44:30+00:00"
+            "time": "2023-09-19T04:57:46+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1097,16 +1097,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.11",
+            "version": "9.6.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "810500e92855eba8a7a5319ae913be2da6f957b0"
+                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/810500e92855eba8a7a5319ae913be2da6f957b0",
-                "reference": "810500e92855eba8a7a5319ae913be2da6f957b0",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f3d767f7f9e191eab4189abe41ab37797e30b1be",
+                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be",
                 "shasum": ""
             },
             "require": {
@@ -1121,7 +1121,7 @@
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.13",
+                "phpunit/php-code-coverage": "^9.2.28",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -1180,7 +1180,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.11"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.13"
             },
             "funding": [
                 {
@@ -1196,7 +1196,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-19T07:10:56+00:00"
+            "time": "2023-09-19T05:39:22+00:00"
         },
         {
             "name": "psr/cache",
@@ -2642,16 +2642,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v6.3.3",
+            "version": "v6.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "9915db259f67d21eefee768c1abcf1cc61b1fc9e"
+                "reference": "a1b31d88c0e998168ca7792f222cbecee47428c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/9915db259f67d21eefee768c1abcf1cc61b1fc9e",
-                "reference": "9915db259f67d21eefee768c1abcf1cc61b1fc9e",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/a1b31d88c0e998168ca7792f222cbecee47428c4",
+                "reference": "a1b31d88c0e998168ca7792f222cbecee47428c4",
                 "shasum": ""
             },
             "require": {
@@ -2686,7 +2686,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.3.3"
+                "source": "https://github.com/symfony/finder/tree/v6.3.5"
             },
             "funding": [
                 {
@@ -2702,7 +2702,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-31T08:31:44+00:00"
+            "time": "2023-09-26T12:56:25+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -3246,16 +3246,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.3.2",
+            "version": "v6.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "53d1a83225002635bca3482fcbf963001313fb68"
+                "reference": "13d76d0fb049051ed12a04bef4f9de8715bea339"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/53d1a83225002635bca3482fcbf963001313fb68",
-                "reference": "53d1a83225002635bca3482fcbf963001313fb68",
+                "url": "https://api.github.com/repos/symfony/string/zipball/13d76d0fb049051ed12a04bef4f9de8715bea339",
+                "reference": "13d76d0fb049051ed12a04bef4f9de8715bea339",
                 "shasum": ""
             },
             "require": {
@@ -3312,7 +3312,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.3.2"
+                "source": "https://github.com/symfony/string/tree/v6.3.5"
             },
             "funding": [
                 {
@@ -3328,7 +3328,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-05T08:41:27+00:00"
+            "time": "2023-09-18T10:38:32+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,6 @@
 parameters:
+    scanDirectories:
+        - vendor/swoole/ide-helper
     level: 5
     paths:
         - src

--- a/src/Http/Adapter/Swoole/Server.php
+++ b/src/Http/Adapter/Swoole/Server.php
@@ -4,7 +4,7 @@ namespace Utopia\Http\Adapter\Swoole;
 
 use Swoole\Coroutine;
 use Utopia\Http\Adapter;
-use Swoole\Http\Server as SwooleServer;
+use Swoole\Coroutine\Http\Server as SwooleServer;
 use Swoole\Http\Request as SwooleRequest;
 use Swoole\Http\Response as SwooleResponse;
 
@@ -30,34 +30,19 @@ class Server extends Adapter
 
     public function onRequest(callable $callback)
     {
-        $this->server->on('request', function (SwooleRequest $request, SwooleResponse $response) use ($callback) {
+        $this->server->handle('/', function (SwooleRequest $request, SwooleResponse $response) use ($callback) {
             call_user_func($callback, new Request($request), new Response($response), \strval(Coroutine::getCid()));
         });
     }
 
     public function onWorkerStart(callable $callback)
     {
-        $this->server->on('WorkerStart', $callback);
-    }
-
-    public function onBeforeReload(callable $callback)
-    {
-        $this->server->on('BeforeReload', $callback);
-    }
-
-    public function onAfterReload(callable $callback)
-    {
-        $this->server->on('AfterReload', $callback);
-    }
-
-    public function onBeforeShutdown(callable $callback)
-    {
-        $this->server->on('beforeShutdown', $callback);
+        return;
     }
 
     public function onStart(callable $callback)
     {
-        $this->server->on('start', $callback);
+        call_user_func($callback, $this);
     }
 
     public function start()

--- a/src/Http/Adapter/Swoole/Server.php
+++ b/src/Http/Adapter/Swoole/Server.php
@@ -34,8 +34,8 @@ class Server extends Adapter
         $this->server->handle('/', function (SwooleRequest $request, SwooleResponse $response) use ($callback) {
             $context = \strval(Coroutine::getCid());
 
-            Http::setResource('swooleRequest', fn () => $request);
-            Http::setResource('swooleResponse', fn () => $response);
+            Http::setResource('swooleRequest', fn () => $request, [], $context);
+            Http::setResource('swooleResponse', fn () => $response, [], $context);
 
             call_user_func($callback, new Request($request), new Response($response), $context);
         });

--- a/src/Http/Adapter/Swoole/Server.php
+++ b/src/Http/Adapter/Swoole/Server.php
@@ -31,7 +31,7 @@ class Server extends Adapter
     public function onRequest(callable $callback)
     {
         $this->server->handle('/', function (SwooleRequest $request, SwooleResponse $response) use ($callback) {
-            call_user_func($callback, new Request($request), new Response($response), \strval(Coroutine::getCid()));
+            call_user_func($callback, $request, $response, \strval(Coroutine::getCid()));
         });
     }
 

--- a/src/Http/Adapter/Swoole/Server.php
+++ b/src/Http/Adapter/Swoole/Server.php
@@ -7,6 +7,7 @@ use Utopia\Http\Adapter;
 use Swoole\Coroutine\Http\Server as SwooleServer;
 use Swoole\Http\Request as SwooleRequest;
 use Swoole\Http\Response as SwooleResponse;
+use Utopia\Http\Http;
 
 class Server extends Adapter
 {
@@ -31,7 +32,12 @@ class Server extends Adapter
     public function onRequest(callable $callback)
     {
         $this->server->handle('/', function (SwooleRequest $request, SwooleResponse $response) use ($callback) {
-            call_user_func($callback, $request, $response, \strval(Coroutine::getCid()));
+            $context = \strval(Coroutine::getCid());
+
+            Http::setResource('swooleRequest', fn () => $request);
+            Http::setResource('swooleResponse', fn () => $response);
+
+            call_user_func($callback, new Request($request), new Response($response), $context);
         });
     }
 

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -2,8 +2,6 @@
 
 namespace Utopia\Http;
 
-use Throwable;
-
 class Http
 {
     /**

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -2,6 +2,8 @@
 
 namespace Utopia\Http;
 
+use Throwable;
+
 class Http
 {
     /**
@@ -563,7 +565,15 @@ class Http
 
     public function start()
     {
-        $this->server->onRequest(fn ($request, $response, $context) => $this->run($request, $response, $context));
+        $this->server->onRequest(function ($request, $response, $context) {
+            try {
+                $this->run($request, $response, $context);
+            } finally {
+                if(isset(self::$resourcesCallbacks[$context])) {
+                    unset(self::$resourcesCallbacks[$context]);
+                }
+            }
+        });
         $this->server->onStart(function ($server) {
             $this->resources['utopia'] ??= [];
             $this->resources['utopia']['server'] = $server;

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -375,7 +375,7 @@ class Http
      * @param  array  $list
      * @return array
      */
-    public function getResources(array $list, string $context): array
+    public function getResources(array $list, string $context = 'utopia'): array
     {
         $resources = [];
 

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -829,6 +829,8 @@ class Http
         $route = $this->match($request);
         $groups = ($route instanceof Route) ? $route->getGroups() : [];
 
+        self::setResource('route', fn () => $route);
+
         if (self::REQUEST_METHOD_HEAD == $method) {
             $method = self::REQUEST_METHOD_GET;
             $response->disablePayload();
@@ -871,6 +873,8 @@ class Http
             $this->route = $route;
             $path = \parse_url($request->getURI(), PHP_URL_PATH);
             $route->path($path);
+
+            self::setResource('route', fn () => $route);
         }
 
         if (null !== $route) {

--- a/src/Http/Validator/Assoc.php
+++ b/src/Http/Validator/Assoc.php
@@ -12,6 +12,21 @@ use Utopia\Http\Validator;
 class Assoc extends Validator
 {
     /**
+     * @var int
+     */
+    protected int $length;
+
+    /**
+     * Pass integer length to allow larger json objects
+     *
+     * @param  int  $length
+     */
+    public function __construct(int $length = 65535)
+    {
+        $this->length = $length;
+    }
+
+    /**
      * Get Description
      *
      * Returns validator description
@@ -64,7 +79,7 @@ class Assoc extends Validator
         $jsonString = \json_encode($value);
         $jsonStringSize = \strlen($jsonString);
 
-        if ($jsonStringSize > 65535) {
+        if ($jsonStringSize > $this->length) {
             return false;
         }
 

--- a/tests/e2e/ResponseSwooleTest.php
+++ b/tests/e2e/ResponseSwooleTest.php
@@ -14,4 +14,10 @@ class ResponseSwooleTest extends TestCase
     {
         $this->client = new Client('http://swoole');
     }
+
+    public function testSwooleResources(): void
+    {
+        $response = $this->client->call(Client::METHOD_DELETE, '/swoole-test');
+        $this->assertEquals('DELETE', $response['body']);
+    }
 }

--- a/tests/e2e/server_swoole.php
+++ b/tests/e2e/server_swoole.php
@@ -10,6 +10,6 @@ use function Swoole\Coroutine\run;
 $server = new Server('0.0.0.0', '80');
 $http = new Http($server, 'UTC');
 
-run(function () use($http) {
+run(function () use ($http) {
     $http->start();
 });

--- a/tests/e2e/server_swoole.php
+++ b/tests/e2e/server_swoole.php
@@ -5,11 +5,11 @@ require_once __DIR__.'/init.php';
 use Utopia\Http\Adapter\Swoole\Server;
 use Utopia\Http\Http;
 
+use function Swoole\Coroutine\run;
+
 $server = new Server('0.0.0.0', '80');
 $http = new Http($server, 'UTC');
 
-$server->onWorkerStart(function ($swooleServer, $workerId) {
-    \fwrite(STDOUT, "Worker " . ++$workerId . " started successfully\n");
+run(function () use($http) {
+    $http->start();
 });
-
-$http->start();

--- a/tests/e2e/server_swoole.php
+++ b/tests/e2e/server_swoole.php
@@ -2,10 +2,24 @@
 
 require_once __DIR__.'/init.php';
 
+use Swoole\Http\Request as SwooleRequest;
+use Swoole\Http\Response as SwooleResponse;
 use Utopia\Http\Adapter\Swoole\Server;
 use Utopia\Http\Http;
 
 use function Swoole\Coroutine\run;
+
+Http::delete('/swoole-test')
+    ->inject('swooleRequest')
+    ->inject('swooleResponse')
+    ->action(function (SwooleRequest $swooleRequest, SwooleResponse $swooleResponse) {
+        $method = $swooleRequest->getMethod();
+        $swooleResponse->header('Content-Type', 'text/plain');
+        $swooleResponse->header('Cache-Control', 'no-cache');
+        $swooleResponse->setStatusCode(200);
+        $swooleResponse->write($method);
+        $swooleResponse->end();
+    });
 
 $server = new Server('0.0.0.0', '80');
 $http = new Http($server, 'UTC');


### PR DESCRIPTION
This is proper usage of coroutine http server in Swoole. It prevents error when trying to apply v2 in executor

```

openruntimes-executor  | 
openruntimes-executor  | Warning: Swoole\Server::start(): eventLoop has already been created, unable to start Swoole\Http\Server in /usr/local/vendor/utopia-php/framework/src/Http/Adapter/Swoole/Server.php on line 65
```