### PR TITLE
Fix Swoole coroutine server lifecycle

### DIFF
--- a/src/Http/Adapter/SwooleCoroutine/Server.php
+++ b/src/Http/Adapter/SwooleCoroutine/Server.php
@@ -11,14 +11,20 @@ use Swoole\Http\Response as SwooleResponse;
 
 class Server extends Adapter
 {
-    protected SwooleServer $server;
     protected const REQUEST_CONTAINER_CONTEXT_KEY = '__utopia_http_request_container';
+
+    protected SwooleServer $server;
     protected Container $container;
+
     /** @var callable|null */
     protected $onStartCallback = null;
 
-    public function __construct(string $host, ?string $port = null, array $settings = [], ?Container $container = null)
-    {
+    public function __construct(
+        string $host,
+        ?string $port = null,
+        array $settings = [],
+        ?Container $container = null
+    ) {
         $this->server = new SwooleServer($host, $port, false, true);
         $this->server->set(\array_merge($settings, [
             'http_parse_cookie' => false,
@@ -29,25 +35,23 @@ class Server extends Adapter
     public function onRequest(callable $callback)
     {
         $this->server->handle('/', function (SwooleRequest $request, SwooleResponse $response) use ($callback) {
-            go(function () use ($request, $response, $callback) {
-                $requestContainer = new Container($this->container);
-                $requestContainer->set('swooleRequest', fn () => $request);
-                $requestContainer->set('swooleResponse', fn () => $response);
+            $requestContainer = new Container($this->container);
+            $requestContainer->set('swooleRequest', fn () => $request);
+            $requestContainer->set('swooleResponse', fn () => $response);
 
-                Coroutine::getContext()[self::REQUEST_CONTAINER_CONTEXT_KEY] = $requestContainer;
+            Coroutine::getContext()[self::REQUEST_CONTAINER_CONTEXT_KEY] = $requestContainer;
 
+            try {
                 \call_user_func($callback, new Request($request), new Response($response));
-            });
+            } finally {
+                unset(Coroutine::getContext()[self::REQUEST_CONTAINER_CONTEXT_KEY]);
+            }
         });
     }
 
     public function getContainer(): Container
     {
-        if (Coroutine::getCid() !== -1) {
-            return Coroutine::getContext()[self::REQUEST_CONTAINER_CONTEXT_KEY] ?? $this->container;
-        }
-
-        return $this->container;
+        return Coroutine::getContext()[self::REQUEST_CONTAINER_CONTEXT_KEY] ?? $this->container;
     }
 
     public function getServer(): SwooleServer
@@ -62,11 +66,10 @@ class Server extends Adapter
 
     public function start()
     {
-        go(function () {
-            if ($this->onStartCallback) {
-                \call_user_func($this->onStartCallback, $this);
-            }
-            $this->server->start();
-        });
+        if ($this->onStartCallback) {
+            \call_user_func($this->onStartCallback, $this);
+        }
+
+        $this->server->start();
     }
 }


### PR DESCRIPTION
## Summary
- stop spawning an extra nested coroutine for every HTTP request
- clear the request-scoped DI container from coroutine context after each request
- simplify coroutine server startup so the adapter runs directly in the active coroutine runtime

## Why
Appwrite's switch to the coroutine HTTP adapter exposed a few lifecycle issues in the upstream adapter:

1. Each request was wrapped in an extra `go(...)`, which made request execution less predictable and diverged from the regular Swoole adapter.
2. The request container stored in coroutine context was never cleared, so request-scoped resources could leak across later work in the same coroutine.
3. Startup was also wrapped in `go(...)`, even though this adapter is intended to run inside an existing coroutine runtime.

These changes keep the adapter coroutine-only, but make its request lifecycle explicit and consistent.

## Validation
- `composer format src/Http/Adapter/SwooleCoroutine/Server.php`
- `composer lint src/Http/Adapter/SwooleCoroutine/Server.php`
- `php -l src/Http/Adapter/SwooleCoroutine/Server.php`
- `vendor/bin/phpstan analyse -c phpstan.neon src/Http/Adapter/SwooleCoroutine/Server.php --memory-limit=512M`