### PR TITLE
[codex] Normalize null request paths during routing

### DIFF
--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -678,6 +678,7 @@ class Http
         }
 
         $url = \parse_url($request->getURI(), PHP_URL_PATH);
+        $url = \is_string($url) ? ($url === '' ? '/' : $url) : '/';
         $method = $request->getMethod();
         $method = (self::REQUEST_METHOD_HEAD == $method) ? self::REQUEST_METHOD_GET : $method;
 
@@ -945,6 +946,7 @@ class Http
             $route = self::$wildcardRoute;
             $this->route = $route;
             $path = \parse_url($request->getURI(), PHP_URL_PATH);
+            $path = \is_string($path) ? ($path === '' ? '/' : $path) : '/';
             $route->path($path);
 
             $this->setRequestResource('route', fn () => $route, []);

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -483,6 +483,17 @@ class HttpTest extends TestCase
         }
     }
 
+    public function testCanMatchRootRouteWhenUriHasNoPath(): void
+    {
+        $route = Http::get('/');
+
+        $_SERVER['REQUEST_METHOD'] = Http::REQUEST_METHOD_GET;
+        $_SERVER['REQUEST_URI'] = 'https://example.com?x=1';
+
+        $this->assertSame($route, $this->http->match(new Request()));
+        $this->assertSame($route, $this->http->getRoute());
+    }
+
     public function testCanRunRequest(): void
     {
         // Test head requests
@@ -554,6 +565,31 @@ class HttpTest extends TestCase
 
         $_SERVER['REQUEST_METHOD'] = $method;
         $_SERVER['REQUEST_URI'] = $uri;
+    }
+
+    public function testWildcardRouteWhenUriHasNoPath(): void
+    {
+        $method = $_SERVER['REQUEST_METHOD'] ?? null;
+        $uri = $_SERVER['REQUEST_URI'] ?? null;
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = 'https://example.com?x=1';
+
+        Http::wildcard()
+            ->inject('response')
+            ->action(function ($response) {
+                $response->send('HELLO');
+            });
+
+        \ob_start();
+        @$this->http->run(new Request(), new Response());
+        $result = \ob_get_contents();
+        \ob_end_clean();
+
+        $_SERVER['REQUEST_METHOD'] = $method;
+        $_SERVER['REQUEST_URI'] = $uri;
+
+        $this->assertEquals('HELLO', $result);
     }
 
     public function testCallableStringParametersNotExecuted(): void


### PR DESCRIPTION
# What changed

- Normalize route-matching path extraction so malformed or pathless request URIs fall back to `/` instead of passing `null` into `Router::match()`.
- Add regression coverage for both direct route matching and wildcard fallback when `parse_url(..., PHP_URL_PATH)` does not return a string.

# Why

Edge runs on Swoole workers, and malformed HTTP requests can arrive with a request URI whose parsed path is `null`.

Before this change, `Http::match()` and wildcard fallback passed the raw result of `parse_url($request->getURI(), PHP_URL_PATH)` directly into `Router::match()` / `$route->path(...)`. When `parse_url()` returned `null`, PHP raised a `TypeError` because the router expects a string path.

That uncaught fatal tears down the active Swoole worker process. In edge this shows up as worker exit code `255`, pod restarts, and repeated crashes under malformed traffic.

This change makes the framework normalize those cases to `/`, so malformed or pathless URIs degrade to a normal root-path route lookup instead of crashing the worker.

# Impact

- Prevents malformed requests from killing Swoole workers.
- Keeps the fix at the library boundary so downstream consumers like edge do not need to patch every app individually.

# Validation

- `vendor/bin/phpunit tests/HttpTest.php --filter "testCanMatchRootRouteWhenUriHasNoPath|testWildcardRouteWhenUriHasNoPath"`
- `vendor/bin/pint --test src/Http/Http.php tests/HttpTest.php`
