### PR TITLE
Skip action if response already sent by init hook

### DIFF
--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -693,7 +693,7 @@ class Http
      * @param  Route  $route
      * @param  Request  $request
      */
-    public function execute(Route $route, Request $request): static
+    public function execute(Route $route, Request $request, Response $response): static
     {
         $arguments = [];
         $groups = $route->getGroups();
@@ -955,7 +955,7 @@ class Http
         }
 
         if (null !== $route) {
-            return $this->execute($route, $request);
+            return $this->execute($route, $request, $response);
         } elseif (self::REQUEST_METHOD_OPTIONS == $method) {
             try {
                 foreach ($groups as $group) {

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -720,8 +720,10 @@ class Http
                 }
             }
 
-            $arguments = $this->getArguments($route, $pathValues, $request->getParams());
-            \call_user_func_array($route->getAction(), $arguments);
+            if (!$response->isSent()) {
+                $arguments = $this->getArguments($route, $pathValues, $request->getParams());
+                \call_user_func_array($route->getAction(), $arguments);
+            }
 
             foreach ($groups as $group) {
                 foreach (self::$shutdown as $hook) { // Group shutdown hooks

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -108,7 +108,7 @@ class HttpTest extends TestCase
             });
 
         \ob_start();
-        $this->http->execute($route, new Request());
+        $this->http->execute($route, new Request(), new Response());
         $result = \ob_get_contents();
         \ob_end_clean();
 
@@ -132,7 +132,7 @@ class HttpTest extends TestCase
         \ob_start();
         $request = new UtopiaFPMRequestTest();
         $request::_setParams(['x' => 'param-x', 'y' => 'param-y', 'z' => 'param-z']);
-        $this->http->execute($route, $request);
+        $this->http->execute($route, $request, new Response());
         $result = \ob_get_contents();
         \ob_end_clean();
 
@@ -152,7 +152,7 @@ class HttpTest extends TestCase
         \ob_start();
         $request = new UtopiaFPMRequestTest();
         $request::_setParams(['x' => 'param-x', 'y' => 'param-y']);
-        $this->http->execute($route, $request);
+        $this->http->execute($route, $request, new Response());
         $result = \ob_get_contents();
         \ob_end_clean();
 
@@ -224,7 +224,7 @@ class HttpTest extends TestCase
         \ob_start();
         $request = new UtopiaFPMRequestTest();
         $request::_setParams(['x' => 'param-x', 'y' => 'param-y']);
-        $this->http->execute($route, $request);
+        $this->http->execute($route, $request, new Response());
         $result = \ob_get_contents();
         \ob_end_clean();
 
@@ -234,7 +234,7 @@ class HttpTest extends TestCase
         \ob_start();
         $request = new UtopiaFPMRequestTest();
         $request::_setParams(['x' => 'param-x', 'y' => 'param-y']);
-        $this->http->execute($homepage, $request);
+        $this->http->execute($homepage, $request, new Response());
         $result = \ob_get_contents();
         \ob_end_clean();
 
@@ -264,7 +264,7 @@ class HttpTest extends TestCase
             });
 
         \ob_start();
-        $this->http->execute($route, new Request());
+        $this->http->execute($route, new Request(), new Response());
         $result = \ob_get_contents();
         \ob_end_clean();
 
@@ -280,7 +280,7 @@ class HttpTest extends TestCase
             });
 
         \ob_start();
-        $this->http->execute($route, new Request());
+        $this->http->execute($route, new Request(), new Response());
         $result = \ob_get_contents();
         \ob_end_clean();
 
@@ -348,7 +348,7 @@ class HttpTest extends TestCase
             });
 
         \ob_start();
-        $this->http->execute($route, new Request());
+        $this->http->execute($route, new Request(), new Response());
         $result = \ob_get_contents();
         \ob_end_clean();
 
@@ -356,7 +356,7 @@ class HttpTest extends TestCase
 
         \ob_start();
         $_GET['y'] = 'y-def';
-        $this->http->execute($route, new Request());
+        $this->http->execute($route, new Request(), new Response());
         $result = \ob_get_contents();
         \ob_end_clean();
 
@@ -606,7 +606,7 @@ class HttpTest extends TestCase
             });
 
         \ob_start();
-        $this->http->execute($route, new Request());
+        $this->http->execute($route, new Request(), new Response());
         $result = \ob_get_contents();
         \ob_end_clean();
 
@@ -624,7 +624,7 @@ class HttpTest extends TestCase
         \ob_start();
         $request = new UtopiaFPMRequestTest();
         $request::_setParams(['func' => 'system']);
-        $this->http->execute($route2, $request);
+        $this->http->execute($route2, $request, new Response());
         $result = \ob_get_contents();
         \ob_end_clean();
 
@@ -642,7 +642,7 @@ class HttpTest extends TestCase
             });
 
         \ob_start();
-        $this->http->execute($route3, new Request());
+        $this->http->execute($route3, new Request(), new Response());
         $result = \ob_get_contents();
         \ob_end_clean();
 


### PR DESCRIPTION
## Summary

- Init hooks (e.g. a cache layer) can call `$response->send()` to deliver a cached response directly to the client
- Without this guard, the framework still runs the route action immediately after — doing the full work pipeline before discovering the response was already sent and silently no-op'ing the second `send()`
- This adds a single `isSent()` check before dispatching the action; shutdown hooks still run so metrics, billing, and teardown logic are unaffected

## Test plan

- [ ] Verify that a route whose init hook calls `$response->send()` no longer executes the action
- [ ] Verify that shutdown hooks still execute after a sent-in-init response (metrics, billing, etc.)
- [ ] Verify normal request flow (no init hook sends) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)