### PR TITLE
Normalize array-valued Swoole request headers

### DIFF
--- a/src/Http/Adapter/Swoole/Request.php
+++ b/src/Http/Adapter/Swoole/Request.php
@@ -3,6 +3,7 @@
 namespace Utopia\Http\Adapter\Swoole;
 
 use Swoole\Http\Request as SwooleRequest;
+use Stringable;
 use Utopia\Http\Request as UtopiaRequest;
 
 class Request extends UtopiaRequest
@@ -287,7 +288,9 @@ class Request extends UtopiaRequest
      */
     public function getHeader(string $key, string $default = ''): string
     {
-        return $this->swoole->header[$key] ?? $default;
+        $key = strtolower($key);
+
+        return $this->normalizeHeaderValue($this->swoole->header[$key] ?? $default, $default);
     }
 
     /**
@@ -322,6 +325,27 @@ class Request extends UtopiaRequest
     public function getSwooleRequest(): SwooleRequest
     {
         return $this->swoole;
+    }
+
+    private function normalizeHeaderValue(mixed $value, string $default): string
+    {
+        if (is_array($value)) {
+            for ($i = count($value) - 1; $i >= 0; $i--) {
+                $candidate = $value[$i];
+
+                if (is_scalar($candidate) || $candidate instanceof Stringable) {
+                    return (string) $candidate;
+                }
+            }
+
+            return $default;
+        }
+
+        if (is_scalar($value) || $value instanceof Stringable) {
+            return (string) $value;
+        }
+
+        return $default;
     }
 
     /**

--- a/tests/SwooleRequestTest.php
+++ b/tests/SwooleRequestTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Utopia\Http\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Http\Adapter\Swoole\Request;
+
+class SwooleRequestTest extends TestCase
+{
+    private ?Request $request = null;
+
+    public function setUp(): void
+    {
+        if (!class_exists(\Swoole\Http\Request::class)) {
+            $this->markTestSkipped('The Swoole extension is required for this test.');
+        }
+
+        /** @var \Swoole\Http\Request $swooleRequest */
+        $swooleRequest = new \Swoole\Http\Request();
+        $swooleRequest->header = [];
+
+        $this->request = new Request($swooleRequest);
+    }
+
+    public function tearDown(): void
+    {
+        $this->request = null;
+    }
+
+    public function testCanGetScalarHeaders(): void
+    {
+        $this->request?->getSwooleRequest()->header = [
+            'x-replaced-path' => '/gateway',
+        ];
+
+        $this->assertEquals('/gateway', $this->request?->getHeader('x-replaced-path'));
+    }
+
+    public function testCanNormalizeArrayHeaders(): void
+    {
+        $this->request?->getSwooleRequest()->header = [
+            'x-replaced-path' => ['/client', '/gateway'],
+        ];
+
+        $this->assertEquals('/gateway', $this->request?->getHeader('x-replaced-path'));
+    }
+}


### PR DESCRIPTION
## Summary

- normalize array-valued Swoole header entries before returning them from `Request::getHeader()`
- keep `getHeader()` aligned with its declared `string` return type even when the underlying Swoole request stores repeated header values as arrays
- add a regression test for scalar and multi-value Swoole headers

## Problem

This was hit in production by Appwrite Edge while handling gateway-rewritten requests:

- Sentry incident: [EDGE-PYF](https://appwrite.sentry.io/issues/7301327803/?project=4508341151137792&query=is%3Aunresolved%20issue.category%3A%5Berror%2Coutage%5D&referrer=issue-stream)

The failure mode is:

`TypeError: Utopia\Http\Adapter\Swoole\Request::getHeader(): Return value must be of type string, array returned`

The concrete trigger was Traefik's `replacePath` middleware. It stores the original path in `X-Replaced-Path` via `Header.Add(...)`. If an inbound request already contains the same header, Swoole exposes the combined value as an array. `getHeader()` currently returns that raw array even though its contract is `string`.

## Solution

- lowercase the requested header name before lookup
- normalize the resolved Swoole header value before returning it
- when the header is multi-valued, return the last scalar/stringable entry

Returning the last value matches append-style middleware behavior, including the Traefik `replacePath` case where the middleware-added value is appended after any client-supplied value.

## Why 0.34.x

This issue is currently affecting a consumer pinned to `0.34.*`, so the fix is proposed against `0.34.x` first to make it releasable for that dependency line.

## Testing

- `vendor/bin/pint src/Http/Adapter/Swoole/Request.php tests/SwooleRequestTest.php`
- `vendor/bin/phpunit tests/RequestTest.php tests/SwooleRequestTest.php`
