### PR TITLE
Lower Brotli default compression level to 4

### DIFF
--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -15,6 +15,8 @@ use Utopia\Validator;
 class Http
 {
     public const COMPRESSION_MIN_SIZE_DEFAULT = 1024;
+    public const COMPRESSION_BROTLI_LEVEL_DEFAULT = 4;
+    public const COMPRESSION_ZSTD_LEVEL_DEFAULT = 3;
 
     /**
      * Request method constants

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -2,6 +2,8 @@
 
 namespace Utopia\Http;
 
+use Utopia\Compression\Algorithms\Brotli;
+use Utopia\Compression\Algorithms\Zstd;
 use Utopia\Compression\Compression;
 
 abstract class Response
@@ -625,6 +627,12 @@ abstract class Response
             $algorithm = Compression::fromAcceptEncoding($this->acceptEncoding, $this->compressionSupported);
 
             if ($algorithm) {
+                if ($algorithm instanceof Brotli) {
+                    $algorithm->setLevel(Http::COMPRESSION_BROTLI_LEVEL_DEFAULT);
+                } elseif ($algorithm instanceof Zstd) {
+                    $algorithm->setLevel(Http::COMPRESSION_ZSTD_LEVEL_DEFAULT);
+                }
+
                 $body = $algorithm->compress($body);
                 $this->removeHeader('Content-Length');
                 $this->addHeader('Content-Length', (string) \strlen($body));


### PR DESCRIPTION
## Summary
- Brotli default lowered from library default (11, near-max) to **4** — a sensible, fast setting for an HTTP response path.
- Added explicit Zstd default of **3** (matches the library default; set explicitly for clarity).
- Audited GZIP and Deflate: no public level setter in utopia-php/compression 0.1.4, both use PHP default level 6 — left as-is.

New constants on `Http`:
- `COMPRESSION_BROTLI_LEVEL_DEFAULT = 4`
- `COMPRESSION_ZSTD_LEVEL_DEFAULT = 3`

Applied in `Response::send()` via `instanceof` checks against `Brotli` / `Zstd` after algorithm selection.

## Test plan
- [ ] `composer check` (phpstan) passes
- [ ] `composer test` passes
- [ ] Existing compression e2e tests still pass (response body decompresses correctly at the new level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)