### PR TITLE
Fix: store current route in per-request container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require": {
         "php": ">=8.2",
         "ext-swoole": "*",
-        "utopia-php/di": "0.3.*",
+        "utopia-php/di": "^0.3.2",
         "utopia-php/servers": "0.3.*",
         "utopia-php/compression": "0.1.*",
         "utopia-php/telemetry": "0.2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "836a13c7945c3bf4de3cd30991d29bf0",
+    "content-hash": "0a629fd72a7f6958b59d11324b2436d4",
     "packages": [
         {
             "name": "brick/math",
@@ -1915,16 +1915,16 @@
         },
         {
             "name": "utopia-php/di",
-            "version": "0.3.1",
+            "version": "0.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/di.git",
-                "reference": "68873b7267842315d01d82a83b988bae525eab31"
+                "reference": "07025d721ed5d9be27932e8e640acf1467fc4b9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/di/zipball/68873b7267842315d01d82a83b988bae525eab31",
-                "reference": "68873b7267842315d01d82a83b988bae525eab31",
+                "url": "https://api.github.com/repos/utopia-php/di/zipball/07025d721ed5d9be27932e8e640acf1467fc4b9d",
+                "reference": "07025d721ed5d9be27932e8e640acf1467fc4b9d",
                 "shasum": ""
             },
             "require": {
@@ -1960,9 +1960,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/di/issues",
-                "source": "https://github.com/utopia-php/di/tree/0.3.1"
+                "source": "https://github.com/utopia-php/di/tree/0.3.2"
             },
-            "time": "2026-03-13T05:47:23+00:00"
+            "time": "2026-03-21T07:42:10+00:00"
         },
         {
             "name": "utopia-php/servers",

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -958,7 +958,7 @@ class Http
         }
 
         if (null === $route && null !== self::$wildcardRoute) {
-            $route = self::$wildcardRoute;
+            $route = clone self::$wildcardRoute;
             $path = \parse_url($request->getURI(), PHP_URL_PATH);
             $path = \is_string($path) ? ($path === '' ? '/' : $path) : '/';
             $route->path($path);

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -918,8 +918,6 @@ class Http
         $route = $this->match($request);
         $groups = ($route instanceof Route) ? $route->getGroups() : [];
 
-        $this->setRequestResource('route', fn () => $route, []);
-
         if (self::REQUEST_METHOD_HEAD == $method) {
             $method = self::REQUEST_METHOD_GET;
             $response->disablePayload();

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -111,15 +111,6 @@ class Http
     protected static array $requestHooks = [];
 
     /**
-     * Route
-     *
-     * Memory cached result for chosen route
-     *
-     * @var Route|null
-     */
-    protected ?Route $route = null;
-
-    /**
      * Wildcard route
      * If set, this get's executed if no other route is matched
      *
@@ -530,7 +521,19 @@ class Http
      */
     public function getRoute(): ?Route
     {
-        return $this->route ?? null;
+        $container = $this->server->getContainer();
+
+        if (!$container->has('route')) {
+            return null;
+        }
+
+        try {
+            $route = $container->get('route');
+        } catch (\Throwable) {
+            return null;
+        }
+
+        return $route instanceof Route ? $route : null;
     }
 
     /**
@@ -540,7 +543,7 @@ class Http
      */
     public function setRoute(Route $route): self
     {
-        $this->route = $route;
+        $this->setRequestResource('route', fn () => $route, []);
 
         return $this;
     }
@@ -675,8 +678,12 @@ class Http
      */
     public function match(Request $request, bool $fresh = true): ?Route
     {
-        if (null !== $this->route && !$fresh) {
-            return $this->route;
+        if (!$fresh) {
+            $cached = $this->getRoute();
+
+            if (null !== $cached) {
+                return $cached;
+            }
         }
 
         $url = \parse_url($request->getURI(), PHP_URL_PATH);
@@ -684,9 +691,13 @@ class Http
         $method = $request->getMethod();
         $method = (self::REQUEST_METHOD_HEAD == $method) ? self::REQUEST_METHOD_GET : $method;
 
-        $this->route = Router::match($method, $url);
+        $route = Router::match($method, $url);
 
-        return $this->route;
+        if (null !== $route) {
+            $this->setRequestResource('route', fn () => $route, []);
+        }
+
+        return $route;
     }
 
     /**
@@ -837,7 +848,7 @@ class Http
         $attributes = [
             'url.scheme' => $request->getProtocol(),
             'http.request.method' => $request->getMethod(),
-            'http.route' => $this->route?->getPath(),
+            'http.route' => $this->getRoute()?->getPath(),
             'http.response.status_code' => $response->getStatusCode(),
         ];
         $this->requestDuration->record($requestDuration, $attributes);
@@ -948,7 +959,6 @@ class Http
 
         if (null === $route && null !== self::$wildcardRoute) {
             $route = self::$wildcardRoute;
-            $this->route = $route;
             $path = \parse_url($request->getURI(), PHP_URL_PATH);
             $path = \is_string($path) ? ($path === '' ? '/' : $path) : '/';
             $route->path($path);

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -477,7 +477,6 @@ class HttpTest extends TestCase
             // Fresh match returns new route
             $matched = $this->http->match($request2, fresh: true);
             $this->assertEquals($route2, $matched);
-            $this->assertEquals($route2, $this->http->getRoute());
         } catch (\Exception $e) {
             $this->fail($e->getMessage());
         }

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -477,6 +477,7 @@ class HttpTest extends TestCase
             // Fresh match returns new route
             $matched = $this->http->match($request2, fresh: true);
             $this->assertEquals($route2, $matched);
+            $this->assertEquals($route2, $this->http->getRoute());
         } catch (\Exception $e) {
             $this->fail($e->getMessage());
         }


### PR DESCRIPTION
## Summary
- `Http::$route` was a plain instance property on a shared `Http` instance. Under Swoole coroutines, two concurrent requests could clobber each other's matched route.
- Moves route storage into the per-request DI container (already used via `setRequestResource('route', ...)`) and removes the redundant `$this->route` property.
- `getRoute()`, `setRoute()`, and `match()` now read/write the per-request container; `http.route` telemetry and the wildcard fallback follow the same path.

## Situations this fixes
- `http.route` telemetry getting labeled with another in-flight request's path.
- Hooks calling `$http->getRoute()` (audit logs, permission checks, span naming) seeing another coroutine's route.
- Wildcard fallback assigning `self::$wildcardRoute` to the shared `$this->route` and masking a real match on a concurrent request.
- User code calling `$http->setRoute(...)` from a hook being overwritten by another coroutine.

## Test plan
- [ ] `vendor/bin/phpunit` (pre-existing env failures in this checkout are unrelated — stale vendor `utopia-php/di` signature)
- [ ] Load-test Swoole coroutine server with mixed routes + wildcard; confirm `http.route` telemetry matches the actual route per request

🤖 Generated with [Claude Code](https://claude.com/claude-code)