### PR TITLE
Chore: Update references from master/0.34.x to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [master, "*.x"]
+    branches: [main]
 
 jobs:
   format:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,13 +36,13 @@ When `TYPE` can be:
 
 For the initial start, fork the project and use git clone command to download the repository to your computer. A standard procedure for working on an issue would be to:
 
-1. `git pull`, before creating a new branch, pull the changes from upstream. Your master needs to be up to date.
+1. `git pull`, before creating a new branch, pull the changes from upstream. Your main needs to be up to date.
 
 ```
 $ git pull
 ```
 
-2. Create new branch from `master` like: `doc-548-submit-a-pull-request-section-to-contribution-guide`<br/>
+2. Create new branch from `main` like: `doc-548-submit-a-pull-request-section-to-contribution-guide`<br/>
 
 ```
 $ git checkout -b [name_of_your_new_branch]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <img height="45" src="docs/logo.png" alt="Logo">
 </p>
 
-[![Build Status](https://travis-ci.org/utopia-php/http.svg?branch=master)](https://travis-ci.org/utopia-php/http)
+[![Build Status](https://github.com/utopia-php/http/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/utopia-php/http/actions/workflows/ci.yml)
 ![Total Downloads](https://img.shields.io/packagist/dt/utopia-php/http.svg)
 [![Discord](https://img.shields.io/discord/564160730845151244?label=discord)](https://discord.gg/GSeTUeA)
 
@@ -275,7 +275,7 @@ All code contributions - including those of people having commit access - must g
 
 Fork the project, create a feature branch, and send us a pull request.
 
-You can refer to the [Contributing Guide](https://github.com/utopia-php/http/blob/master/CONTRIBUTING.md) for more info.
+You can refer to the [Contributing Guide](https://github.com/utopia-php/http/blob/main/CONTRIBUTING.md) for more info.
 
 For security issues, please email security@appwrite.io instead of posting a public issue in GitHub.
 


### PR DESCRIPTION
## Summary
Follow-up to #241 now that `main` is the default branch.

- `ci.yml` push trigger: `[master, "*.x"]` → `[main]`.
- `CONTRIBUTING.md`: two references to `master` updated to `main`.
- `README.md`: replace dead Travis CI badge with a GitHub Actions badge pointing at the `ci.yml` workflow on `main`, and fix the `CONTRIBUTING.md` link.

## Test plan
- [ ] CI runs green on this PR
- [ ] After merge, the new Actions badge resolves to the real workflow status

🤖 Generated with [Claude Code](https://claude.com/claude-code)