### PR TITLE
Chore: Upgrade PHPStan to 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     "require-dev": {
         "doctrine/instantiator": "^1.5",
         "laravel/pint": "1.*",
-        "phpstan/phpstan": "1.*",
+        "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^9.5.25",
         "swoole/ide-helper": "4.8.3"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e8f23d1b6e3a46861f6cc37eef30e4a",
+    "content-hash": "7d61467ab074538162535159ae1da884",
     "packages": [
         {
             "name": "brick/math",
@@ -2496,15 +2496,15 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.33",
+            "version": "2.1.51",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37982d6fc7cbb746dda7773530cda557cdf119e1",
-                "reference": "37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dc3b523c45e714c70de2ac5113b958223b55dc59",
+                "reference": "dc3b523c45e714c70de2ac5113b958223b55dc59",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0"
+                "php": "^7.4|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -2545,7 +2545,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-28T20:30:03+00:00"
+            "time": "2026-04-21T18:22:01+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4083,17 +4083,17 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.2"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.2",
         "ext-opentelemetry": "1.0.0",
         "ext-protobuf": "4.26.1"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -28,7 +28,6 @@ class RequestTest extends TestCase
         $this->assertEquals('value2', $this->request->getHeader('custom-new'));
 
         $headers = $this->request->getHeaders();
-        $this->assertIsArray($headers);
         $this->assertCount(2, $headers);
         $this->assertEquals('value1', $headers['custom']);
         $this->assertEquals('value2', $headers['custom-new']);
@@ -329,7 +328,6 @@ class RequestTest extends TestCase
 
         $size = $this->request->getSize();
 
-        $this->assertIsInt($size);
         $this->assertGreaterThan(0, $size);
     }
 }

--- a/tests/e2e/Client.php
+++ b/tests/e2e/Client.php
@@ -64,7 +64,7 @@ class Client
         $cookies = [];
 
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36');
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);


### PR DESCRIPTION
## Summary
- Bump `phpstan/phpstan` from `1.*` to `^2.0` (installed 2.1.51)
- Fix 3 errors surfaced at level 5 by the upgrade:
  - `tests/e2e/Client.php`: pass `true` to `curl_setopt(..., CURLOPT_RETURNTRANSFER, ...)` (param is `bool`, not `int`)
  - `tests/RequestTest.php`: drop redundant `assertIsArray`/`assertIsInt` on already-typed returns (`method.alreadyNarrowedType`)

Level stays at 5.

## Test plan
- [ ] `composer analyze` passes
- [ ] `composer test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)