### PR TITLE
Chore: Switch Pint preset from psr12 to per

### DIFF
--- a/example/src/server.php
+++ b/example/src/server.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/../vendor/autoload.php';
+require_once __DIR__ . '/../vendor/autoload.php';
 
 use Utopia\Http\Http;
 use Utopia\Http\Response;

--- a/pint.json
+++ b/pint.json
@@ -1,3 +1,3 @@
 {
-    "preset": "psr12"
+    "preset": "per"
 }

--- a/src/Http/Adapter/FPM/Request.php
+++ b/src/Http/Adapter/FPM/Request.php
@@ -113,7 +113,7 @@ class Request extends UtopiaRequest
      */
     public function getPort(): string
     {
-        return (string) \parse_url($this->getProtocol().'://'.$this->getServer('HTTP_HOST', ''), PHP_URL_PORT);
+        return (string) \parse_url($this->getProtocol() . '://' . $this->getServer('HTTP_HOST', ''), PHP_URL_PORT);
     }
 
     /**
@@ -125,7 +125,7 @@ class Request extends UtopiaRequest
      */
     public function getHostname(): string
     {
-        $hostname = \parse_url($this->getProtocol().'://'.$this->getServer('HTTP_HOST', ''), PHP_URL_HOST);
+        $hostname = \parse_url($this->getProtocol() . '://' . $this->getServer('HTTP_HOST', ''), PHP_URL_HOST);
         return strtolower((string) ($hostname));
     }
 
@@ -352,7 +352,7 @@ class Request extends UtopiaRequest
             self::METHOD_PUT,
             self::METHOD_PATCH,
             self::METHOD_DELETE => $this->payload,
-            default => $this->queryString
+            default => $this->queryString,
         };
     }
 

--- a/src/Http/Adapter/FPM/Response.php
+++ b/src/Http/Adapter/FPM/Response.php
@@ -60,10 +60,10 @@ class Response extends UtopiaResponse
     {
         if (\is_array($value)) {
             foreach ($value as $v) {
-                \header($key.': '.$v, false);
+                \header($key . ': ' . $v, false);
             }
         } else {
-            \header($key.': '.$value);
+            \header($key . ': ' . $value);
         }
     }
 

--- a/src/Http/Adapter/FPM/Server.php
+++ b/src/Http/Adapter/FPM/Server.php
@@ -7,17 +7,15 @@ use Utopia\Http\Adapter;
 
 class Server extends Adapter
 {
-    public function __construct(private Container $container)
-    {
-    }
+    public function __construct(private Container $container) {}
 
     public function onRequest(callable $callback)
     {
         $request = new Request();
         $response = new Response();
 
-        $this->container->set('fpmRequest', fn () => $request);
-        $this->container->set('fpmResponse', fn () => $response);
+        $this->container->set('fpmRequest', fn() => $request);
+        $this->container->set('fpmResponse', fn() => $response);
 
         \call_user_func($callback, $request, $response);
     }

--- a/src/Http/Adapter/Swoole/Request.php
+++ b/src/Http/Adapter/Swoole/Request.php
@@ -114,7 +114,7 @@ class Request extends UtopiaRequest
 
         return match ($protocol) {
             'http', 'https', 'ws', 'wss' => $protocol,
-            default => 'https'
+            default => 'https',
         };
     }
 
@@ -127,7 +127,7 @@ class Request extends UtopiaRequest
      */
     public function getPort(): string
     {
-        return $this->getHeader('x-forwarded-port', (string) \parse_url($this->getProtocol().'://'.$this->getHeader('x-forwarded-host', $this->getHeader('host')), PHP_URL_PORT));
+        return $this->getHeader('x-forwarded-port', (string) \parse_url($this->getProtocol() . '://' . $this->getHeader('x-forwarded-host', $this->getHeader('host')), PHP_URL_PORT));
     }
 
     /**
@@ -139,7 +139,7 @@ class Request extends UtopiaRequest
      */
     public function getHostname(): string
     {
-        $hostname = \parse_url($this->getProtocol().'://'.$this->getHeader('x-forwarded-host', $this->getHeader('host')), PHP_URL_HOST);
+        $hostname = \parse_url($this->getProtocol() . '://' . $this->getHeader('x-forwarded-host', $this->getHeader('host')), PHP_URL_HOST);
         return strtolower(strval($hostname));
     }
 
@@ -364,7 +364,7 @@ class Request extends UtopiaRequest
             self::METHOD_PUT,
             self::METHOD_PATCH,
             self::METHOD_DELETE => $this->payload,
-            default => $this->queryString
+            default => $this->queryString,
         };
     }
 

--- a/src/Http/Adapter/Swoole/Server.php
+++ b/src/Http/Adapter/Swoole/Server.php
@@ -26,8 +26,8 @@ class Server extends Adapter
     {
         $this->server->on('request', function (SwooleRequest $request, SwooleResponse $response) use ($callback) {
             $requestContainer = new Container($this->container);
-            $requestContainer->set('swooleRequest', fn () => $request);
-            $requestContainer->set('swooleResponse', fn () => $response);
+            $requestContainer->set('swooleRequest', fn() => $request);
+            $requestContainer->set('swooleResponse', fn() => $response);
 
             Coroutine::getContext()[self::REQUEST_CONTAINER_CONTEXT_KEY] = $requestContainer;
 

--- a/src/Http/Adapter/SwooleCoroutine/Request.php
+++ b/src/Http/Adapter/SwooleCoroutine/Request.php
@@ -4,6 +4,4 @@ namespace Utopia\Http\Adapter\SwooleCoroutine;
 
 use Utopia\Http\Adapter\Swoole\Request as SwooleAdapterRequest;
 
-class Request extends SwooleAdapterRequest
-{
-}
+class Request extends SwooleAdapterRequest {}

--- a/src/Http/Adapter/SwooleCoroutine/Response.php
+++ b/src/Http/Adapter/SwooleCoroutine/Response.php
@@ -4,6 +4,4 @@ namespace Utopia\Http\Adapter\SwooleCoroutine;
 
 use Utopia\Http\Adapter\Swoole\Response as SwooleAdapterResponse;
 
-class Response extends SwooleAdapterResponse
-{
-}
+class Response extends SwooleAdapterResponse {}

--- a/src/Http/Adapter/SwooleCoroutine/Server.php
+++ b/src/Http/Adapter/SwooleCoroutine/Server.php
@@ -23,7 +23,7 @@ class Server extends Adapter
         string $host,
         ?string $port = null,
         array $settings = [],
-        ?Container $container = null
+        ?Container $container = null,
     ) {
         $this->server = new SwooleServer($host, $port, false, true);
         $this->server->set($settings);
@@ -34,8 +34,8 @@ class Server extends Adapter
     {
         $this->server->handle('/', function (SwooleRequest $request, SwooleResponse $response) use ($callback) {
             $requestContainer = new Container($this->container);
-            $requestContainer->set('swooleRequest', fn () => $request);
-            $requestContainer->set('swooleResponse', fn () => $response);
+            $requestContainer->set('swooleRequest', fn() => $request);
+            $requestContainer->set('swooleResponse', fn() => $response);
 
             Coroutine::getContext()[self::REQUEST_CONTAINER_CONTEXT_KEY] = $requestContainer;
 

--- a/src/Http/Exception.php
+++ b/src/Http/Exception.php
@@ -2,6 +2,4 @@
 
 namespace Utopia\Http;
 
-class Exception extends \Exception
-{
-}
+class Exception extends \Exception {}

--- a/src/Http/Files.php
+++ b/src/Http/Files.php
@@ -110,7 +110,7 @@ class Files
                 continue;
             }
 
-            $dirPath = $directory.'/'.$path;
+            $dirPath = $directory . '/' . $path;
 
             if (is_dir($dirPath)) {
                 $this->load($dirPath, strval($root));
@@ -163,7 +163,7 @@ class Files
     public function getFileContents(string $uri): mixed
     {
         if (!array_key_exists($uri, $this->loaded)) {
-            throw new Exception('File not found or not loaded: '.$uri);
+            throw new Exception('File not found or not loaded: ' . $uri);
         }
 
         return $this->loaded[$uri]['contents'];
@@ -180,7 +180,7 @@ class Files
     public function getFileMimeType(string $uri): mixed
     {
         if (!array_key_exists($uri, $this->loaded)) {
-            throw new Exception('File not found or not loaded: '.$uri);
+            throw new Exception('File not found or not loaded: ' . $uri);
         }
 
         return $this->loaded[$uri]['mimeType'];

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -177,7 +177,7 @@ class Http
             'http.server.request.duration',
             's',
             null,
-            ['ExplicitBucketBoundaries' => [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]]
+            ['ExplicitBucketBoundaries' => [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]],
         );
 
         // https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserveractive_requests
@@ -430,7 +430,7 @@ class Http
     {
         try {
             return $this->server->getContainer()->get($name);
-        } catch (ContainerExceptionInterface | NotFoundExceptionInterface $e) {
+        } catch (ContainerExceptionInterface|NotFoundExceptionInterface $e) {
             // Normalize DI container errors to the Http layer's "resource" terminology.
             $message = \str_replace('dependency', 'resource', $e->getMessage());
 
@@ -632,7 +632,7 @@ class Http
     {
 
         $this->server->onRequest(
-            fn (Request $request, Response $response) => $this->run($request, $response)
+            fn(Request $request, Response $response) => $this->run($request, $response),
         );
 
         $this->server->onStart(function ($server) {
@@ -646,7 +646,7 @@ class Http
                     \call_user_func_array($hook->getAction(), $arguments);
                 }
             } catch (\Exception $e) {
-                $this->setResource('error', fn () => $e);
+                $this->setResource('error', fn() => $e);
 
                 foreach (self::$errors as $error) { // Global error hooks
                     if (in_array('*', $error->getGroups())) {
@@ -745,7 +745,7 @@ class Http
                 }
             }
         } catch (\Throwable $e) {
-            $this->setRequestResource('error', fn () => $e, []);
+            $this->setRequestResource('error', fn() => $e, []);
 
             foreach ($groups as $group) {
                 foreach (self::$errors as $error) { // Group error hooks
@@ -868,8 +868,8 @@ class Http
             $response->setCompressionSupported($this->compressionSupported);
         }
 
-        $this->setRequestResource('request', fn () => $request);
-        $this->setRequestResource('response', fn () => $response);
+        $this->setRequestResource('request', fn() => $request);
+        $this->setRequestResource('response', fn() => $response);
 
         try {
             foreach (self::$requestHooks as $hook) {
@@ -877,7 +877,7 @@ class Http
                 \call_user_func_array($hook->getAction(), $arguments);
             }
         } catch (\Exception $e) {
-            $this->setRequestResource('error', fn () => $e, []);
+            $this->setRequestResource('error', fn() => $e, []);
 
             foreach (self::$errors as $error) { // Global error hooks
                 if (\in_array('*', $error->getGroups())) {
@@ -907,7 +907,7 @@ class Http
         $route = $this->match($request);
         $groups = ($route instanceof Route) ? $route->getGroups() : [];
 
-        $this->setRequestResource('route', fn () => $route, []);
+        $this->setRequestResource('route', fn() => $route, []);
 
         if (self::REQUEST_METHOD_HEAD == $method) {
             $method = self::REQUEST_METHOD_GET;
@@ -953,7 +953,7 @@ class Http
             $path = \is_string($path) ? ($path === '' ? '/' : $path) : '/';
             $route->path($path);
 
-            $this->setRequestResource('route', fn () => $route, []);
+            $this->setRequestResource('route', fn() => $route, []);
         }
 
         if (null !== $route) {
@@ -986,7 +986,7 @@ class Http
         } else {
             foreach (self::$errors as $error) { // Global error hooks
                 if (\in_array('*', $error->getGroups())) {
-                    $this->setRequestResource('error', fn () => new Exception('Not Found', 404), []);
+                    $this->setRequestResource('error', fn() => new Exception('Not Found', 404), []);
                     \call_user_func_array($error->getAction(), $this->getArguments($error, [], $request->getParams()));
                 }
             }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -391,7 +391,7 @@ abstract class Response
      */
     public function setContentType(string $type, string $charset = ''): static
     {
-        $this->contentType = $type.((!empty($charset) ? '; charset='.$charset : ''));
+        $this->contentType = $type . ((!empty($charset) ? '; charset=' . $charset : ''));
 
         return $this;
     }
@@ -619,10 +619,10 @@ abstract class Response
 
         // Compress body only if all conditions are met:
         if (
-            !$hasContentEncoding &&
-            !empty($this->acceptEncoding) &&
-            $this->isCompressible($this->contentType) &&
-            strlen($body) > $this->compressionMinSize
+            !$hasContentEncoding
+            && !empty($this->acceptEncoding)
+            && $this->isCompressible($this->contentType)
+            && strlen($body) > $this->compressionMinSize
         ) {
             $algorithm = Compression::fromAcceptEncoding($this->acceptEncoding, $this->compressionSupported);
 
@@ -924,7 +924,7 @@ abstract class Response
     {
         $this
             ->setContentType(self::CONTENT_TYPE_JAVASCRIPT, self::CHARSET_UTF8)
-            ->send('parent.'.$callback.'('.\json_encode($data).');');
+            ->send('parent.' . $callback . '(' . \json_encode($data) . ');');
     }
 
     /**
@@ -941,7 +941,7 @@ abstract class Response
     {
         $this
             ->setContentType(self::CONTENT_TYPE_HTML, self::CHARSET_UTF8)
-            ->send('<script type="text/javascript">window.parent.'.$callback.'('.\json_encode($data).');</script>');
+            ->send('<script type="text/javascript">window.parent.' . $callback . '(' . \json_encode($data) . ');</script>');
     }
 
     /**

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -121,24 +121,24 @@ class Router
      * @param string $path
      * @return \Utopia\Http\Route|null
      */
-    public static function match(string $method, string $path): Route|null
+    public static function match(string $method, string $path): ?Route
     {
         if (!array_key_exists($method, self::$routes)) {
             return null;
         }
 
-        $parts = array_values(array_filter(explode('/', $path), fn ($segment) => $segment !== ''));
+        $parts = array_values(array_filter(explode('/', $path), fn($segment) => $segment !== ''));
         $length = count($parts) - 1;
-        $filteredParams = array_filter(self::$params, fn ($i) => $i <= $length);
+        $filteredParams = array_filter(self::$params, fn($i) => $i <= $length);
 
         foreach (self::combinations($filteredParams) as $sample) {
-            $sample = array_filter($sample, fn (int $i) => $i <= $length);
+            $sample = array_filter($sample, fn(int $i) => $i <= $length);
             $match = implode(
                 '/',
                 array_replace(
                     $parts,
-                    array_fill_keys($sample, self::PLACEHOLDER_TOKEN)
-                )
+                    array_fill_keys($sample, self::PLACEHOLDER_TOKEN),
+                ),
             );
 
             if (array_key_exists($match, self::$routes[$method])) {

--- a/src/Http/View.php
+++ b/src/Http/View.php
@@ -57,7 +57,7 @@ class View
 
                 foreach (\explode("\n\n", $value) as $line) {
                     if (\trim($line)) {
-                        $paragraphs .= '<p>'.$line.'</p>';
+                        $paragraphs .= '<p>' . $line . '</p>';
                     }
                 }
 
@@ -215,14 +215,14 @@ class View
             if (\is_array($filter)) {
                 foreach ($filter as $callback) {
                     if (!isset($this->filters[$callback])) {
-                        throw new Exception('Filter "'.$callback.'" is not registered');
+                        throw new Exception('Filter "' . $callback . '" is not registered');
                     }
 
                     $value = $this->filters[$callback]($value);
                 }
             } else {
                 if (!isset($this->filters[$filter])) {
-                    throw new Exception('Filter "'.$filter.'" is not registered');
+                    throw new Exception('Filter "' . $filter . '" is not registered');
                 }
 
                 $value = $this->filters[$filter]($value);
@@ -260,7 +260,7 @@ class View
             include $this->path;
         } else {
             \ob_end_clean();
-            throw new Exception('"'.$this->path.'" view template is not readable');
+            throw new Exception('"' . $this->path . '" view template is not readable');
         }
 
         $html = \ob_get_contents();
@@ -274,10 +274,10 @@ class View
 
             // replacing both with <textarea>$index</textarea> / <pre>$index</pre>
             $html = \str_replace($foundTxt[0], \array_map(function ($el) {
-                return '<textarea>'.$el.'</textarea>';
+                return '<textarea>' . $el . '</textarea>';
             }, \array_keys($foundTxt[0])), $html);
             $html = \str_replace($foundPre[0], \array_map(function ($el) {
-                return '<pre>'.$el.'</pre>';
+                return '<pre>' . $el . '</pre>';
             }, \array_keys($foundPre[0])), $html);
 
             // your stuff
@@ -297,10 +297,10 @@ class View
 
             // Replacing back with content
             $html = \str_replace(\array_map(function ($el) {
-                return '<textarea>'.$el.'</textarea>';
+                return '<textarea>' . $el . '</textarea>';
             }, \array_keys($foundTxt[0])), $foundTxt[0], $html);
             $html = \str_replace(\array_map(function ($el) {
-                return '<pre>'.$el.'</pre>';
+                return '<pre>' . $el . '</pre>';
             }, \array_keys($foundPre[0])), $foundPre[0], $html);
         }
 

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -87,7 +87,7 @@ class HttpTest extends TestCase
 
     public function testCanExecuteRoute(): void
     {
-        $this->container->set('rand', fn () => rand());
+        $this->container->set('rand', fn() => rand());
         $resource = $this->container->get('rand');
 
         $this->http
@@ -386,7 +386,7 @@ class HttpTest extends TestCase
             'DELETE request' => [Http::REQUEST_METHOD_DELETE, '/path1'],
             '1 separators' => [Http::REQUEST_METHOD_GET, '/a/'],
             '2 separators' => [Http::REQUEST_METHOD_GET, '/a/b'],
-            '3 separators' => [Http::REQUEST_METHOD_GET, '/a/b/c']
+            '3 separators' => [Http::REQUEST_METHOD_GET, '/a/b/c'],
         ];
     }
 
@@ -428,15 +428,15 @@ class HttpTest extends TestCase
         $requests = [
             [
                 'path' => '/d/:id',
-                'url' => '/d/'
+                'url' => '/d/',
             ],
             [
                 'path' => '/d/:id/e/:id2',
-                'url' => '/d/123/e/'
+                'url' => '/d/123/e/',
             ],
             [
                 'path' => '/d/:id/e/:id2/f/:id3',
-                'url' => '/d/123/e/456/f/'
+                'url' => '/d/123/e/456/f/',
             ],
         ];
 
@@ -532,7 +532,7 @@ class HttpTest extends TestCase
         Http::init()
             ->action(function () {
                 $route = $this->http->getRoute();
-                $this->container->set('myRoute', fn () => $route);
+                $this->container->set('myRoute', fn() => $route);
             });
 
 
@@ -653,7 +653,7 @@ class HttpTest extends TestCase
     {
         // Register a 'locale' resource returning a Locale instance whose
         // `name` statically resolves to "en".
-        $this->container->set('locale', fn () => new Locale());
+        $this->container->set('locale', fn() => new Locale());
 
         $route = new Route('GET', '/path');
 

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -48,10 +48,9 @@ class RouteTest extends TestCase
 
     public function testCanSetAndGetAction()
     {
-        $this->assertEquals(function (): void {
-        }, $this->route->getAction());
+        $this->assertEquals(function (): void {}, $this->route->getAction());
 
-        $this->route->action(fn () => 'hello world');
+        $this->route->action(fn() => 'hello world');
 
         $this->assertEquals('hello world', $this->route->getAction()());
     }
@@ -74,8 +73,7 @@ class RouteTest extends TestCase
         $this->route
             ->inject('user')
             ->inject('time')
-            ->action(function () {
-            });
+            ->action(function () {});
 
         $this->assertCount(2, $this->route->getInjections());
         $this->assertEquals('user', $this->route->getInjections()['user']['name']);

--- a/tests/e2e/Client.php
+++ b/tests/e2e/Client.php
@@ -55,7 +55,7 @@ class Client
     public function call(string $method, string $path = '', array $headers = [], array $params = [])
     {
         usleep(50000);
-        $ch = curl_init($this->baseUrl.$path.(($method == self::METHOD_GET && !empty($params)) ? '?'.http_build_query($params) : ''));
+        $ch = curl_init($this->baseUrl . $path . (($method == self::METHOD_GET && !empty($params)) ? '?' . http_build_query($params) : ''));
         $responseHeaders = [];
         $responseStatus = -1;
         $responseType = '';
@@ -79,7 +79,7 @@ class Client
             }
 
             if (strtolower(trim($header[0])) == 'set-cookie') {
-                $parsed = $this->parseCookie((string)trim($header[1]));
+                $parsed = $this->parseCookie((string) trim($header[1]));
                 $name = array_key_first($parsed);
                 $cookies[$name] = $parsed[$name];
             }
@@ -93,7 +93,7 @@ class Client
         $responseStatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
         if ((curl_errno($ch)/* || 200 != $responseStatus*/)) {
-            throw new Exception(curl_error($ch).' with status code '.$responseStatus, $responseStatus);
+            throw new Exception(curl_error($ch) . ' with status code ' . $responseStatus, $responseStatus);
         }
 
         curl_close($ch);
@@ -101,7 +101,7 @@ class Client
         $responseHeaders['status-code'] = $responseStatus;
 
         if ($responseStatus === 500) {
-            echo 'Server error('.$method.': '.$path.'. Params: '.json_encode($params).'): '.json_encode($responseBody)."\n";
+            echo 'Server error(' . $method . ': ' . $path . '. Params: ' . json_encode($params) . '): ' . json_encode($responseBody) . "\n";
         }
 
         return [

--- a/tests/e2e/init.php
+++ b/tests/e2e/init.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/../../vendor/autoload.php';
+require_once __DIR__ . '/../../vendor/autoload.php';
 
 use Utopia\Http\Http;
 use Utopia\Http\Request;

--- a/tests/e2e/server-fpm.php
+++ b/tests/e2e/server-fpm.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/init.php';
+require_once __DIR__ . '/init.php';
 
 use Utopia\DI\Container;
 use Utopia\Http\Adapter\FPM\Server;

--- a/tests/e2e/server-swoole.php
+++ b/tests/e2e/server-swoole.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/init.php';
+require_once __DIR__ . '/init.php';
 
 use Swoole\Http\Request as SwooleRequest;
 use Swoole\Http\Response as SwooleResponse;


### PR DESCRIPTION
## Summary
- Switch `pint.json` preset from `psr12` to `per` (PER-CS 2.0, superset of PSR-12).
- Reformat 21 files with the preset's fixers: `concat_space`, `trailing_comma_in_multiline`, `single_line_empty_body`, `function_declaration`, `operator_linebreak`, `nullable_type_declaration`, `types_spaces`, `cast_spaces`.
- Pint version is already latest (1.29.1), no bump needed.

## Test plan
- [ ] `composer format:check` passes
- [ ] `composer test` passes
- [ ] `composer analyze` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)