### PR TITLE
Chore: Bump PHPStan to level 7

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,7 @@
 parameters:
     scanDirectories:
         - vendor/swoole/ide-helper
-    level: 5
+    level: 7
     paths:
         - src
         - tests

--- a/src/Http/Adapter.php
+++ b/src/Http/Adapter.php
@@ -6,8 +6,8 @@ use Utopia\DI\Container;
 
 abstract class Adapter
 {
-    abstract public function onStart(callable $callback);
-    abstract public function onRequest(callable $callback);
-    abstract public function start();
+    abstract public function onStart(callable $callback): void;
+    abstract public function onRequest(callable $callback): void;
+    abstract public function start(): void;
     abstract public function getContainer(): Container;
 }

--- a/src/Http/Adapter/FPM/Request.php
+++ b/src/Http/Adapter/FPM/Request.php
@@ -189,7 +189,7 @@ class Request extends UtopiaRequest
      * Method for querying upload files data. If $key is not found empty array will be returned.
      *
      * @param  string  $key
-     * @return array
+     * @return array<string, mixed>
      */
     public function getFiles(string $key): array
     {
@@ -275,7 +275,13 @@ class Request extends UtopiaRequest
     {
         $headers = $this->generateHeaders();
 
-        return (isset($headers[$key])) ? $headers[$key] : $default;
+        if (!isset($headers[$key])) {
+            return $default;
+        }
+
+        $value = $headers[$key];
+
+        return \is_array($value) ? \implode(', ', $value) : $value;
     }
 
     /**
@@ -316,7 +322,7 @@ class Request extends UtopiaRequest
      *
      * Generate PHP input stream and parse it as an array in order to handle different content type of requests
      *
-     * @return array
+     * @return array<string, mixed>
      */
     protected function generateInput(): array
     {
@@ -331,7 +337,7 @@ class Request extends UtopiaRequest
             $length = (empty($length)) ? \strlen($contentType) : $length;
             $contentType = \substr($contentType, 0, $length);
 
-            $this->rawPayload = \file_get_contents('php://input');
+            $this->rawPayload = \file_get_contents('php://input') ?: '';
 
             switch ($contentType) {
                 case 'application/json':
@@ -361,7 +367,7 @@ class Request extends UtopiaRequest
      *
      * Parse request headers as an array for easy querying using the getHeader method
      *
-     * @return array
+     * @return array<string, string|array<int, string>>
      */
     protected function generateHeaders(): array
     {

--- a/src/Http/Adapter/FPM/Response.php
+++ b/src/Http/Adapter/FPM/Response.php
@@ -74,7 +74,7 @@ class Response extends UtopiaResponse
      *
      * @param  string  $name
      * @param  string  $value
-     * @param  array  $options
+     * @param  array<string, mixed>  $options
      * @return void
      */
     protected function sendCookie(string $name, string $value, array $options): void

--- a/src/Http/Adapter/FPM/Server.php
+++ b/src/Http/Adapter/FPM/Server.php
@@ -9,7 +9,7 @@ class Server extends Adapter
 {
     public function __construct(private Container $container) {}
 
-    public function onRequest(callable $callback)
+    public function onRequest(callable $callback): void
     {
         $request = new Request();
         $response = new Response();
@@ -20,7 +20,7 @@ class Server extends Adapter
         \call_user_func($callback, $request, $response);
     }
 
-    public function onStart(callable $callback)
+    public function onStart(callable $callback): void
     {
         \call_user_func($callback, $this);
     }
@@ -30,7 +30,7 @@ class Server extends Adapter
         return $this->container;
     }
 
-    public function start()
+    public function start(): void
     {
         return;
     }

--- a/src/Http/Adapter/Swoole/Request.php
+++ b/src/Http/Adapter/Swoole/Request.php
@@ -31,7 +31,7 @@ class Request extends UtopiaRequest
      */
     public function getRawPayload(): string
     {
-        return $this->swoole->rawContent();
+        return $this->swoole->rawContent() ?: '';
     }
 
     /**

--- a/src/Http/Adapter/Swoole/Server.php
+++ b/src/Http/Adapter/Swoole/Server.php
@@ -15,6 +15,9 @@ class Server extends Adapter
     protected const REQUEST_CONTAINER_CONTEXT_KEY = '__utopia_http_request_container';
     protected Container $container;
 
+    /**
+     * @param  array<string, mixed>  $settings
+     */
     public function __construct(string $host, ?string $port = null, array $settings = [], int $mode = SWOOLE_PROCESS, ?Container $container = null)
     {
         $this->server = new SwooleServer($host, (int) $port, $mode);
@@ -22,7 +25,7 @@ class Server extends Adapter
         $this->container = $container ?? new Container();
     }
 
-    public function onRequest(callable $callback)
+    public function onRequest(callable $callback): void
     {
         $this->server->on('request', function (SwooleRequest $request, SwooleResponse $response) use ($callback) {
             $requestContainer = new Container($this->container);
@@ -49,7 +52,7 @@ class Server extends Adapter
         return $this->server;
     }
 
-    public function onStart(callable $callback)
+    public function onStart(callable $callback): void
     {
         $this->server->on('start', function () use ($callback) {
             go(function () use ($callback) {
@@ -58,8 +61,8 @@ class Server extends Adapter
         });
     }
 
-    public function start()
+    public function start(): void
     {
-        return $this->server->start();
+        $this->server->start();
     }
 }

--- a/src/Http/Adapter/SwooleCoroutine/Server.php
+++ b/src/Http/Adapter/SwooleCoroutine/Server.php
@@ -19,6 +19,9 @@ class Server extends Adapter
     /** @var callable|null */
     protected $onStartCallback = null;
 
+    /**
+     * @param  array<string, mixed>  $settings
+     */
     public function __construct(
         string $host,
         ?string $port = null,
@@ -30,7 +33,7 @@ class Server extends Adapter
         $this->container = $container ?? new Container();
     }
 
-    public function onRequest(callable $callback)
+    public function onRequest(callable $callback): void
     {
         $this->server->handle('/', function (SwooleRequest $request, SwooleResponse $response) use ($callback) {
             $requestContainer = new Container($this->container);
@@ -57,12 +60,12 @@ class Server extends Adapter
         return $this->server;
     }
 
-    public function onStart(callable $callback)
+    public function onStart(callable $callback): void
     {
         $this->onStartCallback = $callback;
     }
 
-    public function start()
+    public function start(): void
     {
         if ($this->onStartCallback) {
             \call_user_func($this->onStartCallback, $this);

--- a/src/Http/Files.php
+++ b/src/Http/Files.php
@@ -95,6 +95,10 @@ class Files
 
         $handle = opendir(strval($directory));
 
+        if ($handle === false) {
+            throw new Exception("Failed to open directory: {$directory}");
+        }
+
         while ($path = readdir($handle)) {
             $extension = pathinfo($path, PATHINFO_EXTENSION);
 

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -464,7 +464,7 @@ class Http
     /**
      * Set a resource on the given scope.
      *
-     * @param string[] $injections
+     * @param list<string> $injections
      */
     public function setResource(string $name, callable $callback, array $injections = []): void
     {
@@ -474,7 +474,7 @@ class Http
     /**
      * Set a request-scoped resource on the current request's container.
      *
-     * @param string[] $injections
+     * @param list<string> $injections
      */
     protected function setRequestResource(string $name, callable $callback, array $injections = []): void
     {
@@ -516,7 +516,7 @@ class Http
      *
      * Get all application routes
      *
-     * @return array
+     * @return array<string, Route[]>
      */
     public static function getRoutes(): array
     {
@@ -628,7 +628,7 @@ class Http
         return $hook;
     }
 
-    public function start()
+    public function start(): void
     {
 
         $this->server->onRequest(
@@ -779,9 +779,9 @@ class Http
      * Get Arguments
      *
      * @param  Hook  $hook
-     * @param  array  $values
-     * @param  array  $requestParams
-     * @return array
+     * @param  array<string, mixed>  $values
+     * @param  array<string, mixed>  $requestParams
+     * @return array<int, mixed>
      *
      * @throws Exception
      */
@@ -1002,7 +1002,7 @@ class Http
      * Creates an validator instance and validate given value with given rules.
      *
      * @param  string  $key
-     * @param  array  $param
+     * @param  array<string, mixed>  $param
      * @param  mixed  $value
      * @return void
      *

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -28,24 +28,27 @@ abstract class Request
     /**
      * Container for php://input parsed stream as an associative array
      *
-     * @var array|null
+     * @var array<string, mixed>|null
      */
     protected $payload = null;
 
     /**
      * Container for parsed query string params
      *
-     * @var array|null
+     * @var array<string, mixed>|null
      */
     protected $queryString = null;
 
     /**
      * Container for parsed headers
      *
-     * @var array|null
+     * @var array<string, string|array<int, string>>|null
      */
     protected $headers = null;
 
+    /**
+     * @var array<int, string>
+     */
     protected array $trustedIpHeaders = [];
 
     /**
@@ -69,7 +72,7 @@ abstract class Request
      *
      * Get all params of current method
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function getParams(): array
     {
@@ -145,7 +148,7 @@ abstract class Request
      * Set which headers to trust for determining client IP address.
      * Headers are checked in order; the first one found with a valid IP is used.
      *
-     * @param  array  $headers
+     * @param  array<int, string>  $headers
      * @return static
      */
     public function setTrustedIpHeaders(array $headers): static
@@ -244,7 +247,7 @@ abstract class Request
      * Method for querying upload files data. If $key is not found empty array will be returned.
      *
      * @param  string  $key
-     * @return array
+     * @return array<string, mixed>
      */
     abstract public function getFiles(string $key): array;
 
@@ -361,7 +364,7 @@ abstract class Request
                 $headerStrings[] = $key . ': ' . $value;
             }
         }
-        return \mb_strlen(\implode("\n", $headerStrings), '8bit') + \mb_strlen(\file_get_contents('php://input'), '8bit');
+        return \mb_strlen(\implode("\n", $headerStrings), '8bit') + \mb_strlen(\file_get_contents('php://input') ?: '', '8bit');
     }
 
     /**
@@ -486,7 +489,7 @@ abstract class Request
     /**
      * Set query string parameters
      *
-     * @param  array  $params
+     * @param  array<string, mixed>  $params
      * @return static
      */
     public function setQueryString(array $params): static
@@ -499,7 +502,7 @@ abstract class Request
     /**
      * Set payload parameters
      *
-     * @param  array  $params
+     * @param  array<string, mixed>  $params
      * @return static
      */
     public function setPayload(array $params): static
@@ -514,7 +517,7 @@ abstract class Request
      *
      * Parse request headers as an array for easy querying using the getHeader method
      *
-     * @return array
+     * @return array<string, string|array<int, string>>
      */
     protected function generateHeaders(): array
     {
@@ -548,7 +551,7 @@ abstract class Request
      *
      * Generate PHP input stream and parse it as an array in order to handle different content type of requests
      *
-     * @return array
+     * @return array<string, mixed>
      */
     abstract protected function generateInput(): array;
 
@@ -557,7 +560,7 @@ abstract class Request
      *
      * Parse content-range request header for easy access
      *
-     * @return array|null
+     * @return array{unit: string, size: int, start: int, end: int}|null
      */
     protected function parseContentRange(): ?array
     {
@@ -611,7 +614,7 @@ abstract class Request
      *
      * Parse range request header for easy access
      *
-     * @return array|null
+     * @return array<string, mixed>|null
      */
     protected function parseRange(): ?array
     {

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -114,7 +114,7 @@ abstract class Response
     public const STATUS_CODE_NETWORK_AUTHENTICATION_REQUIRED = 511;
 
     /**
-     * @var array
+     * @var array<int, string>
      */
     protected $statusCodes = [
         self::STATUS_CODE_CONTINUE => 'Continue',
@@ -185,7 +185,7 @@ abstract class Response
     /**
      * Mime Types with compression support
      *
-     * @var array
+     * @var array<string, bool>
      */
     private static $compressible = [
         // Text
@@ -290,7 +290,7 @@ abstract class Response
     protected array $headers = [];
 
     /**
-     * @var array
+     * @var array<int, array<string, mixed>>
      */
     protected array $cookies = [];
 
@@ -526,7 +526,7 @@ abstract class Response
      *
      * Return array of all response headers
      *
-     * @return array<string, array<string, string>>
+     * @return array<string, string|array<string>>
      */
     public function getHeaders(): array
     {
@@ -586,7 +586,7 @@ abstract class Response
      *
      * Return array of all response cookies
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     public function getCookies(): array
     {
@@ -795,7 +795,7 @@ abstract class Response
      *
      * @param  string  $name
      * @param  string  $value
-     * @param  array  $options
+     * @param  array<string, mixed>  $options
      * @return void
      */
     abstract protected function sendCookie(string $name, string $value, array $options): void;
@@ -905,7 +905,7 @@ abstract class Response
 
         $this
             ->setContentType(Response::CONTENT_TYPE_JSON, self::CHARSET_UTF8)
-            ->send(\json_encode($data, JSON_UNESCAPED_UNICODE));
+            ->send(\json_encode($data, JSON_UNESCAPED_UNICODE) ?: '');
     }
 
     /**
@@ -917,7 +917,7 @@ abstract class Response
      * @see http://en.wikipedia.org/wiki/JSONP
      *
      * @param  string  $callback
-     * @param  array  $data
+     * @param  array<string, mixed>  $data
      * @return void
      */
     public function jsonp(string $callback, array $data): void
@@ -934,7 +934,7 @@ abstract class Response
      * It sets relevant content type header ('text/html') and convert a PHP array ($data) to valid JSON using native json_encode
      *
      * @param  string  $callback
-     * @param  array  $data
+     * @param  array<string, mixed>  $data
      * @return void
      */
     public function iframe(string $callback, array $data): void

--- a/src/Http/Route.php
+++ b/src/Http/Route.php
@@ -30,7 +30,7 @@ class Route extends Hook
     /**
      * Path params.
      *
-     * @var array<string,array<string, string>>
+     * @var array<string, array<string, int>>
      */
     protected array $pathParams = [];
 
@@ -165,7 +165,7 @@ class Route extends Hook
      *
      * @param \Utopia\Http\Request $request
      * @param string $path
-     * @return array
+     * @return array<string, mixed>
      */
     public function getPathValues(Request $request, string $path = ''): array
     {

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -35,7 +35,7 @@ class Router
     /**
      * Get all registered routes.
      *
-     * @return array
+     * @return array<string, Route[]>
      */
     public static function getRoutes(): array
     {
@@ -177,8 +177,8 @@ class Router
     /**
      * Get all combinations of the given set.
      *
-     * @param array $set
-     * @return iterable
+     * @param array<int, mixed> $set
+     * @return iterable<array<int, mixed>>
      */
     protected static function combinations(array $set): iterable
     {
@@ -200,7 +200,7 @@ class Router
      * Prepare path for matching
      *
      * @param string $path
-     * @return array
+     * @return array{0: string, 1: array<string, int>}
      */
     public static function preparePath(string $path): array
     {

--- a/src/Http/View.php
+++ b/src/Http/View.php
@@ -26,12 +26,12 @@ class View
     protected bool $rendered = false;
 
     /**
-     * @var array
+     * @var array<string, mixed>
      */
     protected array $params = [];
 
     /**
-     * @var array
+     * @var array<string, callable>
      */
     protected array $filters = [];
 
@@ -204,7 +204,7 @@ class View
      * Output and filter value
      *
      * @param  mixed  $value
-     * @param  string|array  $filter
+     * @param  string|array<int, string>  $filter
      * @return mixed
      *
      * @throws Exception
@@ -263,7 +263,7 @@ class View
             throw new Exception('"' . $this->path . '" view template is not readable');
         }
 
-        $html = \ob_get_contents();
+        $html = \ob_get_contents() ?: '';
 
         \ob_end_clean(); //End of build
 
@@ -314,7 +314,7 @@ class View
      *
      * Exec child View components
      *
-     * @param  array|self  $view
+     * @param  array<int, mixed>|self  $view
      * @return string
      *
      * @throws Exception

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -6,37 +6,37 @@ use Tests\E2E\Client;
 
 trait BaseTest
 {
-    public function testResponse()
+    public function testResponse(): void
     {
         $response = $this->client->call(Client::METHOD_GET, '/');
         $this->assertEquals('Hello World!', $response['body']);
     }
 
-    public function testResponseValue()
+    public function testResponseValue(): void
     {
         $response = $this->client->call(Client::METHOD_GET, '/value/123');
         $this->assertEquals('123', $response['body']);
     }
 
-    public function testChunkResponse()
+    public function testChunkResponse(): void
     {
         $response = $this->client->call(Client::METHOD_GET, '/chunked');
         $this->assertEquals('Hello World!', $response['body']);
     }
 
-    public function testRedirect()
+    public function testRedirect(): void
     {
         $response = $this->client->call(Client::METHOD_GET, '/redirect');
         $this->assertEquals('Hello World!', $response['body']);
     }
 
-    public function testFile()
+    public function testFile(): void
     {
         $response = $this->client->call(Client::METHOD_GET, '/humans.txt');
         $this->assertEquals(204, $response['headers']['status-code']);
     }
 
-    public function testSetCookie()
+    public function testSetCookie(): void
     {
         $response = $this->client->call(Client::METHOD_GET, '/set-cookie');
         $this->assertEquals(200, $response['headers']['status-code']);
@@ -44,7 +44,7 @@ trait BaseTest
         $this->assertEquals('value2', $response['cookies']['key2']);
     }
 
-    public function testAliases()
+    public function testAliases(): void
     {
         $paths = ['/aliased', '/aliased-1', '/aliased-2', '/aliased-3'];
 

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -241,7 +241,7 @@ class HttpTest extends TestCase
         $this->assertEquals('init-' . $resource . '-(init-homepage)-param-x*param-y-(shutdown-homepage)-shutdown', $result);
     }
 
-    public function testCanAddAndExecuteHooks()
+    public function testCanAddAndExecuteHooks(): void
     {
         $this->http
             ->init()
@@ -287,7 +287,7 @@ class HttpTest extends TestCase
         $this->assertEquals('x-def', $result);
     }
 
-    public function testAllowRouteOverrides()
+    public function testAllowRouteOverrides(): void
     {
         Http::setAllowOverride(false);
         $this->assertFalse(Http::getAllowOverride());
@@ -317,7 +317,7 @@ class HttpTest extends TestCase
         });
     }
 
-    public function testCanHookThrowExceptions()
+    public function testCanHookThrowExceptions(): void
     {
         $this->http
             ->init()
@@ -363,7 +363,7 @@ class HttpTest extends TestCase
         $this->assertEquals('(init)-y-def-x-def-(shutdown)', $result);
     }
 
-    public function testCanSetRoute()
+    public function testCanSetRoute(): void
     {
         $route = new Route('GET', '/path');
 
@@ -372,6 +372,9 @@ class HttpTest extends TestCase
         $this->assertEquals($this->http->getRoute(), $route);
     }
 
+    /**
+     * @return array<string, array<int, string>>
+     */
     public function providerRouteMatching(): array
     {
         return [
@@ -512,7 +515,7 @@ class HttpTest extends TestCase
 
         \ob_start();
         $this->http->run(new Request(), new Response());
-        $result = \ob_get_contents();
+        $result = \ob_get_contents() ?: '';
         \ob_end_clean();
 
         $_SERVER['REQUEST_METHOD'] = $method;

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -19,7 +19,7 @@ class RequestTest extends TestCase
         $this->request = null;
     }
 
-    public function testCanGetHeaders()
+    public function testCanGetHeaders(): void
     {
         $_SERVER['HTTP_CUSTOM'] = 'value1';
         $_SERVER['HTTP_CUSTOM_NEW'] = 'value2';
@@ -33,7 +33,7 @@ class RequestTest extends TestCase
         $this->assertEquals('value2', $headers['custom-new']);
     }
 
-    public function testCanAddHeaders()
+    public function testCanAddHeaders(): void
     {
         $this->request->addHeader('custom', 'value1');
         $this->request->addHeader('custom-new', 'value2');
@@ -42,7 +42,7 @@ class RequestTest extends TestCase
         $this->assertEquals('value2', $this->request->getHeader('custom-new'));
     }
 
-    public function testCanRemoveHeaders()
+    public function testCanRemoveHeaders(): void
     {
         $this->request->addHeader('custom', 'value1');
         $this->request->addHeader('custom-new', 'value2');
@@ -56,7 +56,7 @@ class RequestTest extends TestCase
         $this->assertEquals('value2', $this->request->getHeader('custom-new'));
     }
 
-    public function testCanGetQueryParameter()
+    public function testCanGetQueryParameter(): void
     {
         $_GET['key'] = 'value';
 
@@ -64,7 +64,7 @@ class RequestTest extends TestCase
         $this->assertEquals($this->request->getQuery('unknown', 'test'), 'test');
     }
 
-    public function testCanSetQueryString()
+    public function testCanSetQueryString(): void
     {
         $this->request->setQueryString(['key' => 'value']);
 
@@ -72,12 +72,12 @@ class RequestTest extends TestCase
         $this->assertEquals($this->request->getQuery('unknown', 'test'), 'test');
     }
 
-    public function testCanGetPayload()
+    public function testCanGetPayload(): void
     {
         $this->assertEquals($this->request->getPayload('unknown', 'test'), 'test');
     }
 
-    public function testCanSetPayload()
+    public function testCanSetPayload(): void
     {
         $this->request->setPayload(['key' => 'value']);
 
@@ -85,12 +85,12 @@ class RequestTest extends TestCase
         $this->assertEquals($this->request->getPayload('unknown', 'test'), 'test');
     }
 
-    public function testCanGetRawPayload()
+    public function testCanGetRawPayload(): void
     {
         $this->assertEquals($this->request->getRawPayload(), '');
     }
 
-    public function testCanGetServer()
+    public function testCanGetServer(): void
     {
         $_SERVER['key'] = 'value';
 
@@ -98,7 +98,7 @@ class RequestTest extends TestCase
         $this->assertEquals($this->request->getServer('unknown', 'test'), 'test');
     }
 
-    public function testCanSetServer()
+    public function testCanSetServer(): void
     {
         $this->request->setServer('key', 'value');
 
@@ -106,7 +106,7 @@ class RequestTest extends TestCase
         $this->assertEquals($this->request->getServer('unknown', 'test'), 'test');
     }
 
-    public function testCanGetCookie()
+    public function testCanGetCookie(): void
     {
         $_COOKIE['key'] = 'value';
 
@@ -114,7 +114,7 @@ class RequestTest extends TestCase
         $this->assertEquals($this->request->getCookie('unknown', 'test'), 'test');
     }
 
-    public function testCanGetProtocol()
+    public function testCanGetProtocol(): void
     {
         $_SERVER['HTTP_X_FORWARDED_PROTO'] = null;
         $_SERVER['REQUEST_SCHEME'] = 'http';
@@ -122,7 +122,7 @@ class RequestTest extends TestCase
         $this->assertEquals('http', $this->request->getProtocol());
     }
 
-    public function testCanGetForwardedProtocol()
+    public function testCanGetForwardedProtocol(): void
     {
         $_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
         $_SERVER['REQUEST_SCHEME'] = 'http';
@@ -130,7 +130,7 @@ class RequestTest extends TestCase
         $this->assertEquals('https', $this->request->getProtocol());
     }
 
-    public function testCanGetMethod()
+    public function testCanGetMethod(): void
     {
         $this->assertEquals('UNKNOWN', $this->request->getMethod());
 
@@ -139,7 +139,7 @@ class RequestTest extends TestCase
         $this->assertEquals('GET', $this->request->getMethod());
     }
 
-    public function testCanGetUri()
+    public function testCanGetUri(): void
     {
         $this->assertEquals('', $this->request->getURI());
 
@@ -148,14 +148,14 @@ class RequestTest extends TestCase
         $this->assertEquals('/index.html', $this->request->getURI());
     }
 
-    public function testCanSetUri()
+    public function testCanSetUri(): void
     {
         $this->request->setURI('/page.html');
 
         $this->assertEquals('/page.html', $this->request->getURI());
     }
 
-    public function testCanGetPort()
+    public function testCanGetPort(): void
     {
         $_SERVER['HTTP_HOST'] = 'localhost:8080';
 
@@ -166,21 +166,21 @@ class RequestTest extends TestCase
         $this->assertEquals('', $this->request->getPort());
     }
 
-    public function testCanGetHostname()
+    public function testCanGetHostname(): void
     {
         $_SERVER['HTTP_HOST'] = 'localhost';
 
         $this->assertEquals('localhost', $this->request->getHostname());
     }
 
-    public function testCanGetHostnameWithPort()
+    public function testCanGetHostnameWithPort(): void
     {
         $_SERVER['HTTP_HOST'] = 'localhost:8080';
 
         $this->assertEquals('localhost', $this->request->getHostname());
     }
 
-    public function testCanGetReferer()
+    public function testCanGetReferer(): void
     {
         $this->assertEquals('default', $this->request->getReferer('default'));
 
@@ -189,7 +189,7 @@ class RequestTest extends TestCase
         $this->assertEquals('referer', $this->request->getReferer('default'));
     }
 
-    public function testCanGetOrigin()
+    public function testCanGetOrigin(): void
     {
         $this->assertEquals('default', $this->request->getOrigin('default'));
 
@@ -198,7 +198,7 @@ class RequestTest extends TestCase
         $this->assertEquals('origin', $this->request->getOrigin('default'));
     }
 
-    public function testCanGetUserAgent()
+    public function testCanGetUserAgent(): void
     {
         $this->assertEquals('default', $this->request->getUserAgent('default'));
 
@@ -207,7 +207,7 @@ class RequestTest extends TestCase
         $this->assertEquals('user-agent', $this->request->getUserAgent('default'));
     }
 
-    public function testCanGetAccept()
+    public function testCanGetAccept(): void
     {
         $this->assertEquals('default', $this->request->getAccept('default'));
 
@@ -216,7 +216,7 @@ class RequestTest extends TestCase
         $this->assertEquals('accept', $this->request->getAccept('default'));
     }
 
-    public function testCanGetContentRange()
+    public function testCanGetContentRange(): void
     {
         $_SERVER['HTTP_CONTENT_RANGE'] = 'bytes 0-499/2000';
 
@@ -268,7 +268,7 @@ class RequestTest extends TestCase
         $this->assertEquals(null, $this->request->getContentRangeSize());
     }
 
-    public function testCanGetRange()
+    public function testCanGetRange(): void
     {
         $_SERVER['HTTP_RANGE'] = 'bytes=0-499';
 
@@ -313,7 +313,7 @@ class RequestTest extends TestCase
         $this->assertEquals(null, $this->request->getRangeEnd());
     }
 
-    public function testCanGetSizeWithArrayHeaders()
+    public function testCanGetSizeWithArrayHeaders(): void
     {
         $this->request->addHeader('content-type', 'application/json');
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -19,7 +19,7 @@ class FPMResponseTest extends TestCase
         $this->response = null;
     }
 
-    public function testCanSetContentType()
+    public function testCanSetContentType(): void
     {
         $contentType = $this->response->setContentType(Response::CONTENT_TYPE_HTML, Response::CHARSET_UTF8);
 
@@ -27,7 +27,7 @@ class FPMResponseTest extends TestCase
         $this->assertInstanceOf('Utopia\Http\Response', $contentType);
     }
 
-    public function testCanSetStatus()
+    public function testCanSetStatus(): void
     {
         $status = $this->response->setStatusCode(Response::STATUS_CODE_OK);
 
@@ -45,7 +45,7 @@ class FPMResponseTest extends TestCase
         $this->fail('Expected exception');
     }
 
-    public function testCanGetStatus()
+    public function testCanGetStatus(): void
     {
         $status = $this->response->setStatusCode(Response::STATUS_CODE_OK);
 
@@ -54,13 +54,13 @@ class FPMResponseTest extends TestCase
         $this->assertEquals(Response::STATUS_CODE_OK, $this->response->getStatusCode());
     }
 
-    public function testCanAddHeader()
+    public function testCanAddHeader(): void
     {
         $result = $this->response->addHeader('key', 'value');
         $this->assertEquals($this->response, $result);
     }
 
-    public function testCanAddCookie()
+    public function testCanAddCookie(): void
     {
         $result = $this->response->addCookie('name', 'value');
         $this->assertEquals($this->response, $result);
@@ -71,7 +71,7 @@ class FPMResponseTest extends TestCase
         $result->getCookies()['cookiename']['value'] = 'cookieValue';
     }
 
-    public function testCanSend()
+    public function testCanSend(): void
     {
         ob_start(); //Start of build
 
@@ -86,7 +86,7 @@ class FPMResponseTest extends TestCase
         $this->assertEquals('body', $html);
     }
 
-    public function testCanSendRedirect()
+    public function testCanSendRedirect(): void
     {
         ob_start(); //Start of build
 
@@ -107,7 +107,7 @@ class FPMResponseTest extends TestCase
         $this->assertEquals('', $html);
     }
 
-    public function testCanSendText()
+    public function testCanSendText(): void
     {
         ob_start(); //Start of build
 
@@ -120,7 +120,7 @@ class FPMResponseTest extends TestCase
         $this->assertEquals('text/plain; charset=UTF-8', $this->response->getContentType());
     }
 
-    public function testCanSendHtml()
+    public function testCanSendHtml(): void
     {
         ob_start(); //Start of build
 
@@ -133,7 +133,7 @@ class FPMResponseTest extends TestCase
         $this->assertEquals('text/html; charset=UTF-8', $this->response->getContentType());
     }
 
-    public function testCanSendJson()
+    public function testCanSendJson(): void
     {
         ob_start(); //Start of build
 
@@ -146,7 +146,7 @@ class FPMResponseTest extends TestCase
         $this->assertEquals('application/json; charset=UTF-8', $this->response->getContentType());
     }
 
-    public function testCanSendJsonp()
+    public function testCanSendJsonp(): void
     {
         ob_start(); //Start of build
 
@@ -159,7 +159,7 @@ class FPMResponseTest extends TestCase
         $this->assertEquals('text/javascript; charset=UTF-8', $this->response->getContentType());
     }
 
-    public function testCanSendIframe()
+    public function testCanSendIframe(): void
     {
         ob_start(); //Start of build
 

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -14,12 +14,12 @@ class RouteTest extends TestCase
         $this->route = new Route('GET', '/');
     }
 
-    public function testCanGetMethod()
+    public function testCanGetMethod(): void
     {
         $this->assertEquals('GET', $this->route->getMethod());
     }
 
-    public function testCanGetAndSetPath()
+    public function testCanGetAndSetPath(): void
     {
         $this->assertEquals('/', $this->route->getPath());
 
@@ -28,7 +28,7 @@ class RouteTest extends TestCase
         $this->assertEquals('/path', $this->route->getPath());
     }
 
-    public function testCanSetAndGetDescription()
+    public function testCanSetAndGetDescription(): void
     {
         $this->assertEquals('', $this->route->getDesc());
 
@@ -37,7 +37,7 @@ class RouteTest extends TestCase
         $this->assertEquals('new route', $this->route->getDesc());
     }
 
-    public function testCanSetAndGetGroups()
+    public function testCanSetAndGetGroups(): void
     {
         $this->assertEquals([], $this->route->getGroups());
 
@@ -46,7 +46,7 @@ class RouteTest extends TestCase
         $this->assertEquals(['api', 'homepage'], $this->route->getGroups());
     }
 
-    public function testCanSetAndGetAction()
+    public function testCanSetAndGetAction(): void
     {
         $this->assertEquals(function (): void {}, $this->route->getAction());
 
@@ -55,7 +55,7 @@ class RouteTest extends TestCase
         $this->assertEquals('hello world', $this->route->getAction()());
     }
 
-    public function testCanGetAndSetParam()
+    public function testCanGetAndSetParam(): void
     {
         $this->assertEquals([], $this->route->getParams());
 
@@ -66,7 +66,7 @@ class RouteTest extends TestCase
         $this->assertCount(2, $this->route->getParams());
     }
 
-    public function testCanInjectResources()
+    public function testCanInjectResources(): void
     {
         $this->assertEquals([], $this->route->getInjections());
 
@@ -80,7 +80,7 @@ class RouteTest extends TestCase
         $this->assertEquals('time', $this->route->getInjections()['time']['name']);
     }
 
-    public function testCanSetAndGetLabels()
+    public function testCanSetAndGetLabels(): void
     {
         $this->assertEquals('default', $this->route->getLabel('key', 'default'));
 
@@ -89,7 +89,7 @@ class RouteTest extends TestCase
         $this->assertEquals('value', $this->route->getLabel('key', 'default'));
     }
 
-    public function testCanSetAndGetHooks()
+    public function testCanSetAndGetHooks(): void
     {
         $this->assertTrue($this->route->getHook());
         $this->route->hook(true);

--- a/tests/UtopiaFPMRequestTest.php
+++ b/tests/UtopiaFPMRequestTest.php
@@ -6,6 +6,9 @@ use Utopia\Http\Adapter\FPM\Request as UtopiaFPMRequest;
 
 class UtopiaFPMRequestTest extends UtopiaFPMRequest
 {
+    /**
+     * @var array<string, mixed>|null
+     */
     private static ?array $params;
 
     /**
@@ -31,7 +34,7 @@ class UtopiaFPMRequestTest extends UtopiaFPMRequest
      *
      * Get all params of current method
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function getParams(): array
     {
@@ -47,10 +50,10 @@ class UtopiaFPMRequestTest extends UtopiaFPMRequest
     /**
      * Function to set a response filter
      *
-     * @param  ?array  $params
+     * @param  array<string, mixed>|null  $params
      * @return void
      */
-    public static function _setParams(?array $params)
+    public static function _setParams(?array $params): void
     {
         self::$params = $params;
     }
@@ -58,7 +61,7 @@ class UtopiaFPMRequestTest extends UtopiaFPMRequest
     /**
      * Return the currently set filter
      *
-     * @return ?array
+     * @return array<string, mixed>|null
      */
     public static function _getParams(): ?array
     {

--- a/tests/e2e/Client.php
+++ b/tests/e2e/Client.php
@@ -46,14 +46,18 @@ class Client
      *
      * @param  string  $method
      * @param  string  $path
-     * @param  array  $params
-     * @param  array  $headers
-     * @return array|string
+     * @param  array<int, string>  $headers
+     * @param  array<string, mixed>  $params
+     * @return array<string, mixed>
      *
      * @throws Exception
      */
-    public function call(string $method, string $path = '', array $headers = [], array $params = [])
+    public function call(string $method, string $path = '', array $headers = [], array $params = []): array
     {
+        if ($method === '') {
+            throw new Exception('HTTP method is required');
+        }
+
         usleep(50000);
         $ch = curl_init($this->baseUrl . $path . (($method == self::METHOD_GET && !empty($params)) ? '?' . http_build_query($params) : ''));
         $responseHeaders = [];
@@ -115,7 +119,7 @@ class Client
      * Parse Cookie String
      *
      * @param string $cookie
-     * @return array
+     * @return array<int|string, mixed>
      */
     public function parseCookie(string $cookie): array
     {


### PR DESCRIPTION
## Summary
- Adds generic array annotations (`array<K, V>`) and missing return types across `src/` and `tests/` to clear level 6.
- Fixes a handful of unchecked `string|false` / `resource|false` call sites (`file_get_contents`, `json_encode`, `ob_get_contents`, `opendir`, Swoole `rawContent`) for level 7.
- Bumps `phpstan.neon` from level 5 → 7.

## Behaviour
No change on the happy path. The only runtime-visible changes are in previously-broken error paths: `opendir()` failure now throws instead of passing `false` into `readdir()`; FPM `getHeader()` joins array-valued headers with `, ` instead of returning an array despite a `: string` return type.

## Test plan
- [x] `vendor/bin/phpstan analyse` — clean at level 7
- [x] `vendor/bin/pint --test` — passes
- [ ] CI on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)