### PR TITLE
Chore: Upgrade PHPUnit to 12, modernize tests, refresh Rector sets

### DIFF
--- a/Dockerfile.swoole
+++ b/Dockerfile.swoole
@@ -13,7 +13,7 @@ RUN composer install --ignore-platform-reqs --optimize-autoloader \
     --no-plugins --no-scripts --prefer-dist \
     `if [ "$TESTING" != "true" ]; then echo "--no-dev"; fi`
 
-FROM appwrite/base:0.5.0 AS final
+FROM appwrite/base:1.2.0 AS final
 LABEL maintainer="team@appwrite.io"
 
 WORKDIR /usr/src/code

--- a/composer.json
+++ b/composer.json
@@ -54,9 +54,9 @@
     "require-dev": {
         "doctrine/instantiator": "^1.5",
         "laravel/pint": "1.*",
-        "phpstan/phpstan": "^2.0",
-        "phpunit/phpunit": "^9.5.25",
-        "rector/rector": "^2.0",
+        "phpstan/phpstan": "^2.1",
+        "phpunit/phpunit": "^12.0",
+        "rector/rector": "^2.4",
         "swoole/ide-helper": "4.8.3"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3634d82a116d09c1fb571f7b0294ee89",
+    "content-hash": "ffcf218a03a3c0e154ccd9029a626747",
     "packages": [
         {
             "name": "brick/math",
@@ -2549,35 +2549,33 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.32",
+            "version": "12.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+                "reference": "876099a072646c7745f673d7aeab5382c4439691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/876099a072646c7745f673d7aeab5382c4439691",
+                "reference": "876099a072646c7745f673d7aeab5382c4439691",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.19.1 || ^5.1.0",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-text-template": "^2.0.4",
-                "sebastian/code-unit-reverse-lookup": "^2.0.3",
-                "sebastian/complexity": "^2.0.3",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/lines-of-code": "^1.0.4",
-                "sebastian/version": "^3.0.2",
-                "theseer/tokenizer": "^1.2.3"
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.3",
+                "phpunit/php-text-template": "^5.0",
+                "sebastian/complexity": "^5.0",
+                "sebastian/environment": "^8.0.3",
+                "sebastian/lines-of-code": "^4.0",
+                "sebastian/version": "^6.0",
+                "theseer/tokenizer": "^2.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.6"
+                "phpunit/phpunit": "^12.5.1"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -2586,7 +2584,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.2.x-dev"
+                    "dev-main": "12.5.x-dev"
                 }
             },
             "autoload": {
@@ -2615,40 +2613,52 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.6"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-08-22T04:23:01+00:00"
+            "time": "2026-04-15T08:23:17+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2675,36 +2685,49 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2026-02-02T14:04:18+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/12b54e689b07a25a9b41e57736dfab6ec9ae5406",
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -2712,7 +2735,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2738,7 +2761,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/6.0.0"
             },
             "funding": [
                 {
@@ -2746,32 +2770,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2025-02-07T04:58:58+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/e1367a453f0eda562eedb4f659e13aa900d66c53",
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2797,7 +2821,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/5.0.0"
             },
             "funding": [
                 {
@@ -2805,32 +2830,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2025-02-07T04:59:16+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -2856,7 +2881,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/8.0.0"
             },
             "funding": [
                 {
@@ -2864,24 +2890,23 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2025-02-07T04:59:38+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.34",
+            "version": "12.5.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
+                "reference": "c54fcf3d6bcb6e96ac2f7e40097dc37b5f139969"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
-                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c54fcf3d6bcb6e96ac2f7e40097dc37b5f139969",
+                "reference": "c54fcf3d6bcb6e96ac2f7e40097dc37b5f139969",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -2891,27 +2916,23 @@
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.32",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.4",
-                "phpunit/php-timer": "^5.0.3",
-                "sebastian/cli-parser": "^1.0.2",
-                "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.10",
-                "sebastian/diff": "^4.0.6",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/exporter": "^4.0.8",
-                "sebastian/global-state": "^5.0.8",
-                "sebastian/object-enumerator": "^4.0.4",
-                "sebastian/resource-operations": "^3.0.4",
-                "sebastian/type": "^3.2.1",
-                "sebastian/version": "^3.0.2"
-            },
-            "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "php": ">=8.3",
+                "phpunit/php-code-coverage": "^12.5.6",
+                "phpunit/php-file-iterator": "^6.0.1",
+                "phpunit/php-invoker": "^6.0.0",
+                "phpunit/php-text-template": "^5.0.0",
+                "phpunit/php-timer": "^8.0.0",
+                "sebastian/cli-parser": "^4.2.0",
+                "sebastian/comparator": "^7.1.6",
+                "sebastian/diff": "^7.0.0",
+                "sebastian/environment": "^8.1.0",
+                "sebastian/exporter": "^7.0.2",
+                "sebastian/global-state": "^8.0.2",
+                "sebastian/object-enumerator": "^7.0.0",
+                "sebastian/recursion-context": "^7.0.1",
+                "sebastian/type": "^6.0.3",
+                "sebastian/version": "^6.0.0",
+                "staabm/side-effects-detector": "^1.0.5"
             },
             "bin": [
                 "phpunit"
@@ -2919,7 +2940,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-main": "12.5-dev"
                 }
             },
             "autoload": {
@@ -2951,31 +2972,15 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.23"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2026-01-27T05:45:00+00:00"
+            "time": "2026-04-18T06:12:49+00:00"
         },
         {
             "name": "rector/rector",
@@ -3039,28 +3044,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.2",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/90f41072d220e5c40df6e8635f5dafba2d9d4d04",
+                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "4.2-dev"
                 }
             },
             "autoload": {
@@ -3083,153 +3088,60 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                }
-            ],
-            "time": "2024-03-02T06:27:43+00:00"
-        },
-        {
-            "name": "sebastian/code-unit",
-            "version": "1.0.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Collection of value objects that represent the PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/code-unit",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
-            },
-            "funding": [
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
                 {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T13:08:54+00:00"
-        },
-        {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
+                    "type": "tidelift"
                 }
             ],
-            "description": "Looks up which function or method a line of code belongs to",
-            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2025-09-14T09:36:45+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.10",
+            "version": "7.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
-                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c769009dee98f494e0edc3fd4f4087501688f11e",
+                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.3",
+                "sebastian/diff": "^7.0",
+                "sebastian/exporter": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.2"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "7.1-dev"
                 }
             },
             "autoload": {
@@ -3268,7 +3180,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.6"
             },
             "funding": [
                 {
@@ -3288,33 +3201,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T09:22:56+00:00"
+            "time": "2026-04-14T08:23:15+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.3",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/bad4316aba5303d0221f43f8cee37eb58d384bbb",
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3337,7 +3250,8 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3345,33 +3259,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:19:30+00:00"
+            "time": "2025-02-07T04:55:25+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.6",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^12.0",
+                "symfony/process": "^7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -3403,7 +3317,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
             },
             "funding": [
                 {
@@ -3411,27 +3326,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:30:58+00:00"
+            "time": "2025-02-07T04:55:46+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/b121608b28a13f721e76ffbbd386d08eff58f3f6",
+                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -3439,7 +3354,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "8.1-dev"
                 }
             },
             "autoload": {
@@ -3458,7 +3373,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -3466,42 +3381,55 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.1.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2026-04-15T12:13:01+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.8",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+                "reference": "016951ae10980765e4e7aee491eb288c64e505b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
-                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/016951ae10980765e4e7aee491eb288c64e505b7",
+                "reference": "016951ae10980765e4e7aee491eb288c64e505b7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.3",
+                "sebastian/recursion-context": "^7.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -3543,7 +3471,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.2"
             },
             "funding": [
                 {
@@ -3563,38 +3492,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:03:27+00:00"
+            "time": "2025-09-24T06:16:11+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.8",
+            "version": "8.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+                "reference": "ef1377171613d09edd25b7816f05be8313f9115d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
-                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ef1377171613d09edd25b7816f05be8313f9115d",
+                "reference": "ef1377171613d09edd25b7816f05be8313f9115d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -3613,13 +3539,14 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.2"
             },
             "funding": [
                 {
@@ -3639,33 +3566,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T07:10:35+00:00"
+            "time": "2025-08-29T11:29:25+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.4",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/97ffee3bcfb5805568d6af7f0f893678fc076d2f",
+                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3688,7 +3615,8 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/4.0.0"
             },
             "funding": [
                 {
@@ -3696,34 +3624,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:20:34+00:00"
+            "time": "2025-02-07T04:57:28+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1effe8e9b8e068e9ae228e542d5d11b5d16db894",
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -3745,7 +3673,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/7.0.0"
             },
             "funding": [
                 {
@@ -3753,32 +3682,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2025-02-07T04:57:48+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/4bfa827c969c98be1e527abd576533293c634f6a",
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3800,7 +3729,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3808,32 +3738,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2025-02-07T04:58:17+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.6",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
-                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -3863,7 +3793,8 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/7.0.1"
             },
             "funding": [
                 {
@@ -3883,86 +3814,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T06:57:39+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-03-14T16:00:52+00:00"
+            "time": "2025-08-13T04:44:59+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/e549163b9760b8f71f191651d22acf32d56d6d4d",
+                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -3985,37 +3862,50 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/6.0.3"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2025-08-09T06:57:12+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/3e6ccf7657d4f0a59200564b08cead899313b53c",
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -4038,7 +3928,8 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/6.0.0"
             },
             "funding": [
                 {
@@ -4046,7 +3937,59 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2025-02-07T05:00:38+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
         },
         {
             "name": "swoole/ide-helper",
@@ -4092,23 +4035,23 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.3.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
-                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.2 || ^8.0"
+                "php": "^8.1"
             },
             "type": "library",
             "autoload": {
@@ -4130,7 +4073,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+                "source": "https://github.com/theseer/tokenizer/tree/2.0.1"
             },
             "funding": [
                 {
@@ -4138,7 +4081,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-17T20:03:58+00:00"
+            "time": "2025-12-08T11:19:18+00:00"
         }
     ],
     "aliases": [],

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
     <testsuite name="unit">
       <directory>./tests</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,4 +14,9 @@
       <file>./tests/e2e/ResponseSwooleTest.php</file>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory>./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,24 +1,17 @@
-<phpunit
-    backupGlobals="false"
-    backupStaticAttributes="false"
-    bootstrap="vendor/autoload.php"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
-    stopOnFailure="false"
->
-    <testsuites>
-        <testsuite name="unit">
-            <directory>./tests</directory>
-            <exclude>./tests/e2e</exclude>
-        </testsuite>
-        <testsuite name="e2e-fpm">
-            <file>./tests/e2e/ResponseFPMTest.php</file>
-        </testsuite>
-        <testsuite name="e2e-swoole">
-            <file>./tests/e2e/ResponseSwooleTest.php</file>
-        </testsuite>
-    </testsuites>
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="unit">
+      <directory>./tests</directory>
+      <exclude>./tests/e2e</exclude>
+      <exclude>./tests/BaseTest.php</exclude>
+      <exclude>./tests/UtopiaFPMRequestTest.php</exclude>
+    </testsuite>
+    <testsuite name="e2e-fpm">
+      <file>./tests/e2e/ResponseFPMTest.php</file>
+    </testsuite>
+    <testsuite name="e2e-swoole">
+      <file>./tests/e2e/ResponseSwooleTest.php</file>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -16,11 +16,10 @@ use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEmptyNullableObjectToAssertInstanceofRector;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Rector\TypeDeclaration\Rector\ClassMethod\ParamTypeByParentCallTypeRector;
-use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
-use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -34,6 +33,11 @@ return RectorConfig::configure()
         SetList::DEAD_CODE,
         SetList::EARLY_RETURN,
         SetList::INSTANCEOF,
+        PHPUnitSetList::PHPUNIT_100,
+        PHPUnitSetList::PHPUNIT_110,
+        PHPUnitSetList::PHPUNIT_120,
+        PHPUnitSetList::PHPUNIT_CODE_QUALITY,
+        PHPUnitSetList::ANNOTATIONS_TO_ATTRIBUTES,
     ])
     ->withImportNames(importShortClasses: false, removeUnusedImports: true)
     ->withSkip([
@@ -44,11 +48,6 @@ return RectorConfig::configure()
         // Changes truthy semantics — "0", null, "" behave differently
         ExplicitBoolCompareRector::class,
         SimplifyEmptyCheckOnEmptyArrayRector::class,
-
-        // Can throw TypeError on previously-working callers (library is public API)
-        TypedPropertyFromAssignsRector::class,
-        TypedPropertyFromStrictConstructorRector::class,
-        ParamTypeByParentCallTypeRector::class,
 
         // Different distribution and failure mode than rand()
         RandomFunctionRector::class,
@@ -68,4 +67,7 @@ return RectorConfig::configure()
 
         // Throws TypeError when args are objects/arrays — review per-call
         NullToStrictStringFuncCallArgRector::class,
+
+        // Weakens `assertNull` to `assertNotInstanceOf` — keep the stricter assertion
+        AssertEmptyNullableObjectToAssertInstanceofRector::class,
     ]);

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -9,39 +9,39 @@ trait BaseTest
     public function testResponse(): void
     {
         $response = $this->client->call(Client::METHOD_GET, '/');
-        $this->assertEquals('Hello World!', $response['body']);
+        $this->assertSame('Hello World!', $response['body']);
     }
 
     public function testResponseValue(): void
     {
         $response = $this->client->call(Client::METHOD_GET, '/value/123');
-        $this->assertEquals('123', $response['body']);
+        $this->assertSame('123', $response['body']);
     }
 
     public function testChunkResponse(): void
     {
         $response = $this->client->call(Client::METHOD_GET, '/chunked');
-        $this->assertEquals('Hello World!', $response['body']);
+        $this->assertSame('Hello World!', $response['body']);
     }
 
     public function testRedirect(): void
     {
         $response = $this->client->call(Client::METHOD_GET, '/redirect');
-        $this->assertEquals('Hello World!', $response['body']);
+        $this->assertSame('Hello World!', $response['body']);
     }
 
     public function testFile(): void
     {
         $response = $this->client->call(Client::METHOD_GET, '/humans.txt');
-        $this->assertEquals(204, $response['headers']['status-code']);
+        $this->assertSame(204, $response['headers']['status-code']);
     }
 
     public function testSetCookie(): void
     {
         $response = $this->client->call(Client::METHOD_GET, '/set-cookie');
-        $this->assertEquals(200, $response['headers']['status-code']);
-        $this->assertEquals('value1', $response['cookies']['key1']);
-        $this->assertEquals('value2', $response['cookies']['key2']);
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame('value1', $response['cookies']['key1']);
+        $this->assertSame('value2', $response['cookies']['key2']);
     }
 
     public function testAliases(): void
@@ -50,8 +50,8 @@ trait BaseTest
 
         foreach ($paths as $path) {
             $response = $this->client->call(Client::METHOD_GET, $path);
-            $this->assertEquals(200, $response['headers']['status-code']);
-            $this->assertEquals('Aliased!', $response['body']);
+            $this->assertSame(200, $response['headers']['status-code']);
+            $this->assertSame('Aliased!', $response['body']);
         }
     }
 }

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Utopia\Http;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Utopia\DI\Container;
 use Utopia\Http\Tests\UtopiaFPMRequestTest;
@@ -10,7 +13,7 @@ use Utopia\Http\Adapter\FPM\Request;
 use Utopia\Http\Adapter\FPM\Response;
 use Utopia\Http\Adapter\FPM\Server;
 
-class HttpTest extends TestCase
+final class HttpTest extends TestCase
 {
     protected ?Http $http;
 
@@ -56,21 +59,21 @@ class HttpTest extends TestCase
 
         Http::setMode(Http::MODE_TYPE_PRODUCTION);
 
-        $this->assertEquals(Http::MODE_TYPE_PRODUCTION, Http::getMode());
+        $this->assertSame(Http::MODE_TYPE_PRODUCTION, Http::getMode());
         $this->assertTrue(Http::isProduction());
         $this->assertFalse(Http::isDevelopment());
         $this->assertFalse(Http::isStage());
 
         Http::setMode(Http::MODE_TYPE_DEVELOPMENT);
 
-        $this->assertEquals(Http::MODE_TYPE_DEVELOPMENT, Http::getMode());
+        $this->assertSame(Http::MODE_TYPE_DEVELOPMENT, Http::getMode());
         $this->assertFalse(Http::isProduction());
         $this->assertTrue(Http::isDevelopment());
         $this->assertFalse(Http::isStage());
 
         Http::setMode(Http::MODE_TYPE_STAGE);
 
-        $this->assertEquals(Http::MODE_TYPE_STAGE, Http::getMode());
+        $this->assertSame(Http::MODE_TYPE_STAGE, Http::getMode());
         $this->assertFalse(Http::isProduction());
         $this->assertFalse(Http::isDevelopment());
         $this->assertTrue(Http::isStage());
@@ -81,8 +84,8 @@ class HttpTest extends TestCase
         // Mock
         $_SERVER['key'] = 'value';
 
-        $this->assertEquals(Http::getEnv('key'), 'value');
-        $this->assertEquals(Http::getEnv('unknown', 'test'), 'test');
+        $this->assertSame('value', Http::getEnv('key'));
+        $this->assertSame('test', Http::getEnv('unknown', 'test'));
     }
 
     public function testCanExecuteRoute(): void
@@ -136,7 +139,7 @@ class HttpTest extends TestCase
         $result = \ob_get_contents();
         \ob_end_clean();
 
-        $this->assertEquals($resource . '-param-x-param-y', $result);
+        $this->assertSame($resource . '-param-x-param-y', $result);
 
         // With Error
         $resource = $this->container->get('rand');
@@ -156,7 +159,7 @@ class HttpTest extends TestCase
         $result = \ob_get_contents();
         \ob_end_clean();
 
-        $this->assertEquals('error: Invalid `x` param: Value must be a valid string and no longer than 1 chars', $result);
+        $this->assertSame('error: Invalid `x` param: Value must be a valid string and no longer than 1 chars', $result);
 
         // With Hooks
         $resource = $this->container->get('rand');
@@ -228,7 +231,7 @@ class HttpTest extends TestCase
         $result = \ob_get_contents();
         \ob_end_clean();
 
-        $this->assertEquals('init-' . $resource . '-(init-api)-param-x-param-y-(shutdown-api)-shutdown', $result);
+        $this->assertSame('init-' . $resource . '-(init-api)-param-x-param-y-(shutdown-api)-shutdown', $result);
 
         $resource = $this->container->get('rand');
         \ob_start();
@@ -238,7 +241,7 @@ class HttpTest extends TestCase
         $result = \ob_get_contents();
         \ob_end_clean();
 
-        $this->assertEquals('init-' . $resource . '-(init-homepage)-param-x*param-y-(shutdown-homepage)-shutdown', $result);
+        $this->assertSame('init-' . $resource . '-(init-homepage)-param-x*param-y-(shutdown-homepage)-shutdown', $result);
     }
 
     public function testCanAddAndExecuteHooks(): void
@@ -268,7 +271,7 @@ class HttpTest extends TestCase
         $result = \ob_get_contents();
         \ob_end_clean();
 
-        $this->assertEquals('(init)-x-def-(shutdown)', $result);
+        $this->assertSame('(init)-x-def-(shutdown)', $result);
 
         // Default Params
         $route = new Route('GET', '/path');
@@ -284,7 +287,7 @@ class HttpTest extends TestCase
         $result = \ob_get_contents();
         \ob_end_clean();
 
-        $this->assertEquals('x-def', $result);
+        $this->assertSame('x-def', $result);
     }
 
     public function testAllowRouteOverrides(): void
@@ -302,7 +305,7 @@ class HttpTest extends TestCase
             $this->fail('Failed to throw exception');
         } catch (\Exception $e) {
             // Threw exception as expected
-            $this->assertEquals('Route for (GET:) already registered.', $e->getMessage());
+            $this->assertSame('Route for (GET:) already registered.', $e->getMessage());
         }
 
         // Test success
@@ -352,7 +355,7 @@ class HttpTest extends TestCase
         $result = \ob_get_contents();
         \ob_end_clean();
 
-        $this->assertEquals('error-Param "y" is not optional.', $result);
+        $this->assertSame('error-Param "y" is not optional.', $result);
 
         \ob_start();
         $_GET['y'] = 'y-def';
@@ -360,42 +363,38 @@ class HttpTest extends TestCase
         $result = \ob_get_contents();
         \ob_end_clean();
 
-        $this->assertEquals('(init)-y-def-x-def-(shutdown)', $result);
+        $this->assertSame('(init)-y-def-x-def-(shutdown)', $result);
     }
 
     public function testCanSetRoute(): void
     {
         $route = new Route('GET', '/path');
 
-        $this->assertEquals($this->http->getRoute(), null);
+        $this->assertNull($this->http->getRoute());
         $this->http->setRoute($route);
         $this->assertEquals($this->http->getRoute(), $route);
     }
 
     /**
-     * @return array<string, array<int, string>>
+     * @return \Iterator<string, array<int, string>>
      */
-    public function providerRouteMatching(): array
+    public static function providerRouteMatching(): \Iterator
     {
-        return [
-            'GET request' => [Http::REQUEST_METHOD_GET, '/path1'],
-            'GET request on different route' => [Http::REQUEST_METHOD_GET, '/path2'],
-            'GET request with trailing slash #1' => [Http::REQUEST_METHOD_GET, '/path3', '/path3/'],
-            'GET request with trailing slash #2' => [Http::REQUEST_METHOD_GET, '/path3/', '/path3/'],
-            'GET request with trailing slash #3' => [Http::REQUEST_METHOD_GET, '/path3/', '/path3'],
-            'POST request' => [Http::REQUEST_METHOD_POST, '/path1'],
-            'PUT request' => [Http::REQUEST_METHOD_PUT, '/path1'],
-            'PATCH request' => [Http::REQUEST_METHOD_PATCH, '/path1'],
-            'DELETE request' => [Http::REQUEST_METHOD_DELETE, '/path1'],
-            '1 separators' => [Http::REQUEST_METHOD_GET, '/a/'],
-            '2 separators' => [Http::REQUEST_METHOD_GET, '/a/b'],
-            '3 separators' => [Http::REQUEST_METHOD_GET, '/a/b/c'],
-        ];
+        yield 'GET request' => [Http::REQUEST_METHOD_GET, '/path1'];
+        yield 'GET request on different route' => [Http::REQUEST_METHOD_GET, '/path2'];
+        yield 'GET request with trailing slash #1' => [Http::REQUEST_METHOD_GET, '/path3', '/path3/'];
+        yield 'GET request with trailing slash #2' => [Http::REQUEST_METHOD_GET, '/path3/', '/path3/'];
+        yield 'GET request with trailing slash #3' => [Http::REQUEST_METHOD_GET, '/path3/', '/path3'];
+        yield 'POST request' => [Http::REQUEST_METHOD_POST, '/path1'];
+        yield 'PUT request' => [Http::REQUEST_METHOD_PUT, '/path1'];
+        yield 'PATCH request' => [Http::REQUEST_METHOD_PATCH, '/path1'];
+        yield 'DELETE request' => [Http::REQUEST_METHOD_DELETE, '/path1'];
+        yield '1 separators' => [Http::REQUEST_METHOD_GET, '/a/'];
+        yield '2 separators' => [Http::REQUEST_METHOD_GET, '/a/b'];
+        yield '3 separators' => [Http::REQUEST_METHOD_GET, '/a/b/c'];
     }
 
-    /**
-     * @dataProvider providerRouteMatching
-     */
+    #[DataProvider('providerRouteMatching')]
     public function testCanMatchRoute(string $method, string $path, ?string $url = null): void
     {
         $url ??= $path;
@@ -451,8 +450,8 @@ class HttpTest extends TestCase
 
             $route = $this->http->match(new Request(), fresh: true);
 
-            $this->assertEquals(null, $route);
-            $this->assertEquals(null, $this->http->getRoute());
+            $this->assertNull($route);
+            $this->assertNull($this->http->getRoute());
         }
     }
 
@@ -555,7 +554,7 @@ class HttpTest extends TestCase
         $result = \ob_get_contents();
         \ob_end_clean();
 
-        $this->assertEquals('HELLO', $result);
+        $this->assertSame('HELLO', $result);
 
         \ob_start();
         $req = new Request();
@@ -564,7 +563,7 @@ class HttpTest extends TestCase
         $result = \ob_get_contents();
         \ob_end_clean();
 
-        $this->assertEquals('', $result);
+        $this->assertSame('', $result);
 
         $_SERVER['REQUEST_METHOD'] = $method;
         $_SERVER['REQUEST_URI'] = $uri;
@@ -592,7 +591,7 @@ class HttpTest extends TestCase
         $_SERVER['REQUEST_METHOD'] = $method;
         $_SERVER['REQUEST_URI'] = $uri;
 
-        $this->assertEquals('HELLO', $result);
+        $this->assertSame('HELLO', $result);
     }
 
     public function testCallableStringParametersNotExecuted(): void
@@ -613,7 +612,7 @@ class HttpTest extends TestCase
         $result = \ob_get_contents();
         \ob_end_clean();
 
-        $this->assertEquals('callback-value: phpinfo', $result);
+        $this->assertSame('callback-value: phpinfo', $result);
 
         // Test with request parameter that is a callable string
         $route2 = new Route('GET', '/test-callable-string-param');
@@ -631,7 +630,7 @@ class HttpTest extends TestCase
         $result = \ob_get_contents();
         \ob_end_clean();
 
-        $this->assertEquals('func-value: system', $result);
+        $this->assertSame('func-value: system', $result);
 
         // Test callable closure still works
         $route3 = new Route('GET', '/test-callable-closure');
@@ -647,7 +646,7 @@ class HttpTest extends TestCase
         $result = \ob_get_contents();
         \ob_end_clean();
 
-        $this->assertEquals('generated: generated-value', $result);
+        $this->assertSame('generated: generated-value', $result);
     }
 
     public function testCanInjectResourceAndParamWithSameName(): void

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -372,7 +372,7 @@ final class HttpTest extends TestCase
 
         $this->assertNull($this->http->getRoute());
         $this->http->setRoute($route);
-        $this->assertEquals($this->http->getRoute(), $route);
+        $this->assertSame($route, $this->http->getRoute());
     }
 
     /**
@@ -421,8 +421,8 @@ final class HttpTest extends TestCase
         $_SERVER['REQUEST_METHOD'] = $method;
         $_SERVER['REQUEST_URI'] = $url;
 
-        $this->assertEquals($expected, $this->http->match(new Request()));
-        $this->assertEquals($expected, $this->http->getRoute());
+        $this->assertSame($expected, $this->http->match(new Request()));
+        $this->assertSame($expected, $this->http->getRoute());
     }
 
     public function testNoMismatchRoute(): void
@@ -465,21 +465,21 @@ final class HttpTest extends TestCase
             $_SERVER['REQUEST_METHOD'] = 'HEAD';
             $_SERVER['REQUEST_URI'] = '/path1';
             $matched = $this->http->match(new Request());
-            $this->assertEquals($route1, $matched);
-            $this->assertEquals($route1, $this->http->getRoute());
+            $this->assertSame($route1, $matched);
+            $this->assertSame($route1, $this->http->getRoute());
 
             // Second request match returns cached route
             $_SERVER['REQUEST_METHOD'] = 'HEAD';
             $_SERVER['REQUEST_URI'] = '/path2';
             $request2 = new Request();
             $matched = $this->http->match($request2, fresh: false);
-            $this->assertEquals($route1, $matched);
-            $this->assertEquals($route1, $this->http->getRoute());
+            $this->assertSame($route1, $matched);
+            $this->assertSame($route1, $this->http->getRoute());
 
             // Fresh match returns new route
             $matched = $this->http->match($request2, fresh: true);
-            $this->assertEquals($route2, $matched);
-            $this->assertEquals($route2, $this->http->getRoute());
+            $this->assertSame($route2, $matched);
+            $this->assertSame($route2, $this->http->getRoute());
         } catch (\Exception $e) {
             $this->fail($e->getMessage());
         }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Utopia\Http\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Utopia\Http\Adapter\FPM\Request;
 
-class RequestTest extends TestCase
+final class RequestTest extends TestCase
 {
     protected ?Request $request;
 
@@ -24,13 +26,13 @@ class RequestTest extends TestCase
         $_SERVER['HTTP_CUSTOM'] = 'value1';
         $_SERVER['HTTP_CUSTOM_NEW'] = 'value2';
 
-        $this->assertEquals('value1', $this->request->getHeader('custom'));
-        $this->assertEquals('value2', $this->request->getHeader('custom-new'));
+        $this->assertSame('value1', $this->request->getHeader('custom'));
+        $this->assertSame('value2', $this->request->getHeader('custom-new'));
 
         $headers = $this->request->getHeaders();
         $this->assertCount(2, $headers);
-        $this->assertEquals('value1', $headers['custom']);
-        $this->assertEquals('value2', $headers['custom-new']);
+        $this->assertSame('value1', $headers['custom']);
+        $this->assertSame('value2', $headers['custom-new']);
     }
 
     public function testCanAddHeaders(): void
@@ -38,8 +40,8 @@ class RequestTest extends TestCase
         $this->request->addHeader('custom', 'value1');
         $this->request->addHeader('custom-new', 'value2');
 
-        $this->assertEquals('value1', $this->request->getHeader('custom'));
-        $this->assertEquals('value2', $this->request->getHeader('custom-new'));
+        $this->assertSame('value1', $this->request->getHeader('custom'));
+        $this->assertSame('value2', $this->request->getHeader('custom-new'));
     }
 
     public function testCanRemoveHeaders(): void
@@ -47,71 +49,71 @@ class RequestTest extends TestCase
         $this->request->addHeader('custom', 'value1');
         $this->request->addHeader('custom-new', 'value2');
 
-        $this->assertEquals('value1', $this->request->getHeader('custom'));
-        $this->assertEquals('value2', $this->request->getHeader('custom-new'));
+        $this->assertSame('value1', $this->request->getHeader('custom'));
+        $this->assertSame('value2', $this->request->getHeader('custom-new'));
 
         $this->request->removeHeader('custom');
 
-        $this->assertEquals(null, $this->request->getHeader('custom'));
-        $this->assertEquals('value2', $this->request->getHeader('custom-new'));
+        $this->assertSame('', $this->request->getHeader('custom'));
+        $this->assertSame('value2', $this->request->getHeader('custom-new'));
     }
 
     public function testCanGetQueryParameter(): void
     {
         $_GET['key'] = 'value';
 
-        $this->assertEquals($this->request->getQuery('key'), 'value');
-        $this->assertEquals($this->request->getQuery('unknown', 'test'), 'test');
+        $this->assertSame('value', $this->request->getQuery('key'));
+        $this->assertSame('test', $this->request->getQuery('unknown', 'test'));
     }
 
     public function testCanSetQueryString(): void
     {
         $this->request->setQueryString(['key' => 'value']);
 
-        $this->assertEquals($this->request->getQuery('key'), 'value');
-        $this->assertEquals($this->request->getQuery('unknown', 'test'), 'test');
+        $this->assertSame('value', $this->request->getQuery('key'));
+        $this->assertSame('test', $this->request->getQuery('unknown', 'test'));
     }
 
     public function testCanGetPayload(): void
     {
-        $this->assertEquals($this->request->getPayload('unknown', 'test'), 'test');
+        $this->assertSame('test', $this->request->getPayload('unknown', 'test'));
     }
 
     public function testCanSetPayload(): void
     {
         $this->request->setPayload(['key' => 'value']);
 
-        $this->assertEquals($this->request->getPayload('key'), 'value');
-        $this->assertEquals($this->request->getPayload('unknown', 'test'), 'test');
+        $this->assertSame('value', $this->request->getPayload('key'));
+        $this->assertSame('test', $this->request->getPayload('unknown', 'test'));
     }
 
     public function testCanGetRawPayload(): void
     {
-        $this->assertEquals($this->request->getRawPayload(), '');
+        $this->assertSame('', $this->request->getRawPayload());
     }
 
     public function testCanGetServer(): void
     {
         $_SERVER['key'] = 'value';
 
-        $this->assertEquals($this->request->getServer('key'), 'value');
-        $this->assertEquals($this->request->getServer('unknown', 'test'), 'test');
+        $this->assertSame('value', $this->request->getServer('key'));
+        $this->assertSame('test', $this->request->getServer('unknown', 'test'));
     }
 
     public function testCanSetServer(): void
     {
         $this->request->setServer('key', 'value');
 
-        $this->assertEquals($this->request->getServer('key'), 'value');
-        $this->assertEquals($this->request->getServer('unknown', 'test'), 'test');
+        $this->assertSame('value', $this->request->getServer('key'));
+        $this->assertSame('test', $this->request->getServer('unknown', 'test'));
     }
 
     public function testCanGetCookie(): void
     {
         $_COOKIE['key'] = 'value';
 
-        $this->assertEquals($this->request->getCookie('key'), 'value');
-        $this->assertEquals($this->request->getCookie('unknown', 'test'), 'test');
+        $this->assertSame('value', $this->request->getCookie('key'));
+        $this->assertSame('test', $this->request->getCookie('unknown', 'test'));
     }
 
     public function testCanGetProtocol(): void
@@ -119,7 +121,7 @@ class RequestTest extends TestCase
         $_SERVER['HTTP_X_FORWARDED_PROTO'] = null;
         $_SERVER['REQUEST_SCHEME'] = 'http';
 
-        $this->assertEquals('http', $this->request->getProtocol());
+        $this->assertSame('http', $this->request->getProtocol());
     }
 
     public function testCanGetForwardedProtocol(): void
@@ -127,190 +129,190 @@ class RequestTest extends TestCase
         $_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
         $_SERVER['REQUEST_SCHEME'] = 'http';
 
-        $this->assertEquals('https', $this->request->getProtocol());
+        $this->assertSame('https', $this->request->getProtocol());
     }
 
     public function testCanGetMethod(): void
     {
-        $this->assertEquals('UNKNOWN', $this->request->getMethod());
+        $this->assertSame('UNKNOWN', $this->request->getMethod());
 
         $_SERVER['REQUEST_METHOD'] = 'GET';
 
-        $this->assertEquals('GET', $this->request->getMethod());
+        $this->assertSame('GET', $this->request->getMethod());
     }
 
     public function testCanGetUri(): void
     {
-        $this->assertEquals('', $this->request->getURI());
+        $this->assertSame('', $this->request->getURI());
 
         $_SERVER['REQUEST_URI'] = '/index.html';
 
-        $this->assertEquals('/index.html', $this->request->getURI());
+        $this->assertSame('/index.html', $this->request->getURI());
     }
 
     public function testCanSetUri(): void
     {
         $this->request->setURI('/page.html');
 
-        $this->assertEquals('/page.html', $this->request->getURI());
+        $this->assertSame('/page.html', $this->request->getURI());
     }
 
     public function testCanGetPort(): void
     {
         $_SERVER['HTTP_HOST'] = 'localhost:8080';
 
-        $this->assertEquals('8080', $this->request->getPort());
+        $this->assertSame('8080', $this->request->getPort());
 
         $_SERVER['HTTP_HOST'] = 'localhost';
 
-        $this->assertEquals('', $this->request->getPort());
+        $this->assertSame('', $this->request->getPort());
     }
 
     public function testCanGetHostname(): void
     {
         $_SERVER['HTTP_HOST'] = 'localhost';
 
-        $this->assertEquals('localhost', $this->request->getHostname());
+        $this->assertSame('localhost', $this->request->getHostname());
     }
 
     public function testCanGetHostnameWithPort(): void
     {
         $_SERVER['HTTP_HOST'] = 'localhost:8080';
 
-        $this->assertEquals('localhost', $this->request->getHostname());
+        $this->assertSame('localhost', $this->request->getHostname());
     }
 
     public function testCanGetReferer(): void
     {
-        $this->assertEquals('default', $this->request->getReferer('default'));
+        $this->assertSame('default', $this->request->getReferer('default'));
 
         $_SERVER['HTTP_REFERER'] = 'referer';
 
-        $this->assertEquals('referer', $this->request->getReferer('default'));
+        $this->assertSame('referer', $this->request->getReferer('default'));
     }
 
     public function testCanGetOrigin(): void
     {
-        $this->assertEquals('default', $this->request->getOrigin('default'));
+        $this->assertSame('default', $this->request->getOrigin('default'));
 
         $_SERVER['HTTP_ORIGIN'] = 'origin';
 
-        $this->assertEquals('origin', $this->request->getOrigin('default'));
+        $this->assertSame('origin', $this->request->getOrigin('default'));
     }
 
     public function testCanGetUserAgent(): void
     {
-        $this->assertEquals('default', $this->request->getUserAgent('default'));
+        $this->assertSame('default', $this->request->getUserAgent('default'));
 
         $_SERVER['HTTP_USER_AGENT'] = 'user-agent';
 
-        $this->assertEquals('user-agent', $this->request->getUserAgent('default'));
+        $this->assertSame('user-agent', $this->request->getUserAgent('default'));
     }
 
     public function testCanGetAccept(): void
     {
-        $this->assertEquals('default', $this->request->getAccept('default'));
+        $this->assertSame('default', $this->request->getAccept('default'));
 
         $_SERVER['HTTP_ACCEPT'] = 'accept';
 
-        $this->assertEquals('accept', $this->request->getAccept('default'));
+        $this->assertSame('accept', $this->request->getAccept('default'));
     }
 
     public function testCanGetContentRange(): void
     {
         $_SERVER['HTTP_CONTENT_RANGE'] = 'bytes 0-499/2000';
 
-        $this->assertEquals('bytes', $this->request->getContentRangeUnit());
-        $this->assertEquals(0, $this->request->getContentRangeStart());
-        $this->assertEquals(499, $this->request->getContentRangeEnd());
-        $this->assertEquals(2000, $this->request->getContentRangeSize());
+        $this->assertSame('bytes', $this->request->getContentRangeUnit());
+        $this->assertSame(0, $this->request->getContentRangeStart());
+        $this->assertSame(499, $this->request->getContentRangeEnd());
+        $this->assertSame(2000, $this->request->getContentRangeSize());
 
         $_SERVER['HTTP_CONTENT_RANGE'] = ' 0-499/2000';
         $this->request = new Request();
-        $this->assertEquals(null, $this->request->getContentRangeUnit());
-        $this->assertEquals(null, $this->request->getContentRangeStart());
-        $this->assertEquals(null, $this->request->getContentRangeEnd());
-        $this->assertEquals(null, $this->request->getContentRangeSize());
+        $this->assertNull($this->request->getContentRangeUnit());
+        $this->assertNull($this->request->getContentRangeStart());
+        $this->assertNull($this->request->getContentRangeEnd());
+        $this->assertNull($this->request->getContentRangeSize());
 
         $_SERVER['HTTP_CONTENT_RANGE'] = 'bytes 0-499/';
         $this->request = new Request();
-        $this->assertEquals(null, $this->request->getContentRangeUnit());
-        $this->assertEquals(null, $this->request->getContentRangeStart());
-        $this->assertEquals(null, $this->request->getContentRangeEnd());
-        $this->assertEquals(null, $this->request->getContentRangeSize());
+        $this->assertNull($this->request->getContentRangeUnit());
+        $this->assertNull($this->request->getContentRangeStart());
+        $this->assertNull($this->request->getContentRangeEnd());
+        $this->assertNull($this->request->getContentRangeSize());
 
         $_SERVER['HTTP_CONTENT_RANGE'] = 'bytes 0--499/2000';
         $this->request = new Request();
-        $this->assertEquals(null, $this->request->getContentRangeUnit());
-        $this->assertEquals(null, $this->request->getContentRangeStart());
-        $this->assertEquals(null, $this->request->getContentRangeEnd());
-        $this->assertEquals(null, $this->request->getContentRangeSize());
+        $this->assertNull($this->request->getContentRangeUnit());
+        $this->assertNull($this->request->getContentRangeStart());
+        $this->assertNull($this->request->getContentRangeEnd());
+        $this->assertNull($this->request->getContentRangeSize());
 
         $_SERVER['HTTP_CONTENT_RANGE'] = 'bytes 0-499test/2000';
         $this->request = new Request();
-        $this->assertEquals(null, $this->request->getContentRangeUnit());
-        $this->assertEquals(null, $this->request->getContentRangeStart());
-        $this->assertEquals(null, $this->request->getContentRangeEnd());
-        $this->assertEquals(null, $this->request->getContentRangeSize());
+        $this->assertNull($this->request->getContentRangeUnit());
+        $this->assertNull($this->request->getContentRangeStart());
+        $this->assertNull($this->request->getContentRangeEnd());
+        $this->assertNull($this->request->getContentRangeSize());
 
         $_SERVER['HTTP_CONTENT_RANGE'] = 'bytes 0-49.9/200.0';
         $this->request = new Request();
-        $this->assertEquals(null, $this->request->getContentRangeUnit());
-        $this->assertEquals(null, $this->request->getContentRangeStart());
-        $this->assertEquals(null, $this->request->getContentRangeEnd());
-        $this->assertEquals(null, $this->request->getContentRangeSize());
+        $this->assertNull($this->request->getContentRangeUnit());
+        $this->assertNull($this->request->getContentRangeStart());
+        $this->assertNull($this->request->getContentRangeEnd());
+        $this->assertNull($this->request->getContentRangeSize());
 
         $_SERVER['HTTP_CONTENT_RANGE'] = 'bytes 0-49,9/200,0';
         $this->request = new Request();
-        $this->assertEquals(null, $this->request->getContentRangeUnit());
-        $this->assertEquals(null, $this->request->getContentRangeStart());
-        $this->assertEquals(null, $this->request->getContentRangeEnd());
-        $this->assertEquals(null, $this->request->getContentRangeSize());
+        $this->assertNull($this->request->getContentRangeUnit());
+        $this->assertNull($this->request->getContentRangeStart());
+        $this->assertNull($this->request->getContentRangeEnd());
+        $this->assertNull($this->request->getContentRangeSize());
     }
 
     public function testCanGetRange(): void
     {
         $_SERVER['HTTP_RANGE'] = 'bytes=0-499';
 
-        $this->assertEquals('bytes', $this->request->getRangeUnit());
-        $this->assertEquals(0, $this->request->getRangeStart());
-        $this->assertEquals(499, $this->request->getRangeEnd());
+        $this->assertSame('bytes', $this->request->getRangeUnit());
+        $this->assertSame(0, $this->request->getRangeStart());
+        $this->assertSame(499, $this->request->getRangeEnd());
 
         $_SERVER['HTTP_RANGE'] = ' 0-499';
         $this->request = new Request();
-        $this->assertEquals(null, $this->request->getRangeUnit());
-        $this->assertEquals(null, $this->request->getRangeStart());
-        $this->assertEquals(null, $this->request->getRangeEnd());
+        $this->assertNull($this->request->getRangeUnit());
+        $this->assertNull($this->request->getRangeStart());
+        $this->assertNull($this->request->getRangeEnd());
 
         $_SERVER['HTTP_RANGE'] = 'bytes=0-';
         $this->request = new Request();
-        $this->assertEquals('bytes', $this->request->getRangeUnit());
-        $this->assertEquals(0, $this->request->getRangeStart());
-        $this->assertEquals(null, $this->request->getRangeEnd());
+        $this->assertSame('bytes', $this->request->getRangeUnit());
+        $this->assertSame(0, $this->request->getRangeStart());
+        $this->assertNull($this->request->getRangeEnd());
 
         $_SERVER['HTTP_RANGE'] = 'bytes=0--499';
         $this->request = new Request();
-        $this->assertEquals(null, $this->request->getRangeUnit());
-        $this->assertEquals(null, $this->request->getRangeStart());
-        $this->assertEquals(null, $this->request->getRangeEnd());
+        $this->assertNull($this->request->getRangeUnit());
+        $this->assertNull($this->request->getRangeStart());
+        $this->assertNull($this->request->getRangeEnd());
 
         $_SERVER['HTTP_RANGE'] = 'bytes=0-499test';
         $this->request = new Request();
-        $this->assertEquals(null, $this->request->getRangeUnit());
-        $this->assertEquals(null, $this->request->getRangeStart());
-        $this->assertEquals(null, $this->request->getRangeEnd());
+        $this->assertNull($this->request->getRangeUnit());
+        $this->assertNull($this->request->getRangeStart());
+        $this->assertNull($this->request->getRangeEnd());
 
         $_SERVER['HTTP_RANGE'] = 'bytes=0-49.9';
         $this->request = new Request();
-        $this->assertEquals(null, $this->request->getRangeUnit());
-        $this->assertEquals(null, $this->request->getRangeStart());
-        $this->assertEquals(null, $this->request->getRangeEnd());
+        $this->assertNull($this->request->getRangeUnit());
+        $this->assertNull($this->request->getRangeStart());
+        $this->assertNull($this->request->getRangeEnd());
 
         $_SERVER['HTTP_RANGE'] = 'bytes=0-49,9';
         $this->request = new Request();
-        $this->assertEquals(null, $this->request->getRangeUnit());
-        $this->assertEquals(null, $this->request->getRangeStart());
-        $this->assertEquals(null, $this->request->getRangeEnd());
+        $this->assertNull($this->request->getRangeUnit());
+        $this->assertNull($this->request->getRangeStart());
+        $this->assertNull($this->request->getRangeEnd());
     }
 
     public function testCanGetSizeWithArrayHeaders(): void

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -59,13 +59,13 @@ final class FPMResponseTest extends TestCase
     public function testCanAddHeader(): void
     {
         $result = $this->response->addHeader('key', 'value');
-        $this->assertEquals($this->response, $result);
+        $this->assertSame($this->response, $result);
     }
 
     public function testCanAddCookie(): void
     {
         $result = $this->response->addCookie('name', 'value');
-        $this->assertEquals($this->response, $result);
+        $this->assertSame($this->response, $result);
 
         //test cookie case insensitive
         $result = $this->response->addCookie('cookieName', 'cookieValue');

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Utopia\Http;
 
 use PHPUnit\Framework\TestCase;
 use Utopia\Http\Adapter\FPM\Response;
 
-class FPMResponseTest extends TestCase
+final class FPMResponseTest extends TestCase
 {
     protected ?Response $response;
 
@@ -51,7 +53,7 @@ class FPMResponseTest extends TestCase
 
         // Assertions
         $this->assertInstanceOf('Utopia\Http\Response', $status);
-        $this->assertEquals(Response::STATUS_CODE_OK, $this->response->getStatusCode());
+        $this->assertSame(Response::STATUS_CODE_OK, $this->response->getStatusCode());
     }
 
     public function testCanAddHeader(): void
@@ -83,7 +85,7 @@ class FPMResponseTest extends TestCase
         $html = ob_get_contents();
         ob_end_clean(); //End of build
 
-        $this->assertEquals('body', $html);
+        $this->assertSame('body', $html);
     }
 
     public function testCanSendRedirect(): void
@@ -95,7 +97,7 @@ class FPMResponseTest extends TestCase
         $html = ob_get_contents();
         ob_end_clean(); //End of build
 
-        $this->assertEquals('', $html);
+        $this->assertSame('', $html);
 
         ob_start(); //Start of build
 
@@ -104,7 +106,7 @@ class FPMResponseTest extends TestCase
         $html = ob_get_contents();
         ob_end_clean(); //End of build
 
-        $this->assertEquals('', $html);
+        $this->assertSame('', $html);
     }
 
     public function testCanSendText(): void
@@ -116,8 +118,8 @@ class FPMResponseTest extends TestCase
         $html = ob_get_contents();
         ob_end_clean(); //End of build
 
-        $this->assertEquals('HELLO WORLD', $html);
-        $this->assertEquals('text/plain; charset=UTF-8', $this->response->getContentType());
+        $this->assertSame('HELLO WORLD', $html);
+        $this->assertSame('text/plain; charset=UTF-8', $this->response->getContentType());
     }
 
     public function testCanSendHtml(): void
@@ -129,8 +131,8 @@ class FPMResponseTest extends TestCase
         $html = ob_get_contents();
         ob_end_clean(); //End of build
 
-        $this->assertEquals('<html></html>', $html);
-        $this->assertEquals('text/html; charset=UTF-8', $this->response->getContentType());
+        $this->assertSame('<html></html>', $html);
+        $this->assertSame('text/html; charset=UTF-8', $this->response->getContentType());
     }
 
     public function testCanSendJson(): void
@@ -142,8 +144,8 @@ class FPMResponseTest extends TestCase
         $html = ob_get_contents();
         ob_end_clean(); //End of build
 
-        $this->assertEquals('{"key":"value"}', $html);
-        $this->assertEquals('application/json; charset=UTF-8', $this->response->getContentType());
+        $this->assertSame('{"key":"value"}', $html);
+        $this->assertSame('application/json; charset=UTF-8', $this->response->getContentType());
     }
 
     public function testCanSendJsonp(): void
@@ -155,8 +157,8 @@ class FPMResponseTest extends TestCase
         $html = ob_get_contents();
         ob_end_clean(); //End of build
 
-        $this->assertEquals('parent.test({"key":"value"});', $html);
-        $this->assertEquals('text/javascript; charset=UTF-8', $this->response->getContentType());
+        $this->assertSame('parent.test({"key":"value"});', $html);
+        $this->assertSame('text/javascript; charset=UTF-8', $this->response->getContentType());
     }
 
     public function testCanSendIframe(): void
@@ -168,7 +170,7 @@ class FPMResponseTest extends TestCase
         $html = ob_get_contents();
         ob_end_clean(); //End of build
 
-        $this->assertEquals('<script type="text/javascript">window.parent.test({"key":"value"});</script>', $html);
-        $this->assertEquals('text/html; charset=UTF-8', $this->response->getContentType());
+        $this->assertSame('<script type="text/javascript">window.parent.test({"key":"value"});</script>', $html);
+        $this->assertSame('text/html; charset=UTF-8', $this->response->getContentType());
     }
 }

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Utopia\Http;
 
 use PHPUnit\Framework\TestCase;
 use Utopia\Validator\Text;
 
-class RouteTest extends TestCase
+final class RouteTest extends TestCase
 {
     protected ?Route $route;
 
@@ -16,48 +18,48 @@ class RouteTest extends TestCase
 
     public function testCanGetMethod(): void
     {
-        $this->assertEquals('GET', $this->route->getMethod());
+        $this->assertSame('GET', $this->route->getMethod());
     }
 
     public function testCanGetAndSetPath(): void
     {
-        $this->assertEquals('/', $this->route->getPath());
+        $this->assertSame('/', $this->route->getPath());
 
         $this->route->path('/path');
 
-        $this->assertEquals('/path', $this->route->getPath());
+        $this->assertSame('/path', $this->route->getPath());
     }
 
     public function testCanSetAndGetDescription(): void
     {
-        $this->assertEquals('', $this->route->getDesc());
+        $this->assertSame('', $this->route->getDesc());
 
         $this->route->desc('new route');
 
-        $this->assertEquals('new route', $this->route->getDesc());
+        $this->assertSame('new route', $this->route->getDesc());
     }
 
     public function testCanSetAndGetGroups(): void
     {
-        $this->assertEquals([], $this->route->getGroups());
+        $this->assertSame([], $this->route->getGroups());
 
         $this->route->groups(['api', 'homepage']);
 
-        $this->assertEquals(['api', 'homepage'], $this->route->getGroups());
+        $this->assertSame(['api', 'homepage'], $this->route->getGroups());
     }
 
     public function testCanSetAndGetAction(): void
     {
-        $this->assertEquals(function (): void {}, $this->route->getAction());
+        $this->assertInstanceOf(\Closure::class, $this->route->getAction());
 
         $this->route->action(fn() => 'hello world');
 
-        $this->assertEquals('hello world', $this->route->getAction()());
+        $this->assertSame('hello world', $this->route->getAction()());
     }
 
     public function testCanGetAndSetParam(): void
     {
-        $this->assertEquals([], $this->route->getParams());
+        $this->assertSame([], $this->route->getParams());
 
         $this->route
             ->param('x', '', new Text(10))
@@ -68,7 +70,7 @@ class RouteTest extends TestCase
 
     public function testCanInjectResources(): void
     {
-        $this->assertEquals([], $this->route->getInjections());
+        $this->assertSame([], $this->route->getInjections());
 
         $this->route
             ->inject('user')
@@ -76,17 +78,17 @@ class RouteTest extends TestCase
             ->action(function () {});
 
         $this->assertCount(2, $this->route->getInjections());
-        $this->assertEquals('user', $this->route->getInjections()['user']['name']);
-        $this->assertEquals('time', $this->route->getInjections()['time']['name']);
+        $this->assertSame('user', $this->route->getInjections()['user']['name']);
+        $this->assertSame('time', $this->route->getInjections()['time']['name']);
     }
 
     public function testCanSetAndGetLabels(): void
     {
-        $this->assertEquals('default', $this->route->getLabel('key', 'default'));
+        $this->assertSame('default', $this->route->getLabel('key', 'default'));
 
         $this->route->label('key', 'value');
 
-        $this->assertEquals('value', $this->route->getLabel('key', 'default'));
+        $this->assertSame('value', $this->route->getLabel('key', 'default'));
     }
 
     public function testCanSetAndGetHooks(): void

--- a/tests/e2e/Client.php
+++ b/tests/e2e/Client.php
@@ -97,8 +97,6 @@ class Client
             throw new Exception(curl_error($ch) . ' with status code ' . $responseStatus, $responseStatus);
         }
 
-        curl_close($ch);
-
         $responseHeaders['status-code'] = $responseStatus;
 
         if ($responseStatus === 500) {

--- a/tests/e2e/ResponseFPMTest.php
+++ b/tests/e2e/ResponseFPMTest.php
@@ -7,7 +7,7 @@ namespace Utopia\Http\Tests;
 use PHPUnit\Framework\TestCase;
 use Tests\E2E\Client;
 
-class ResponseFPMTest extends TestCase
+final class ResponseFPMTest extends TestCase
 {
     use BaseTest;
     protected Client $client;
@@ -21,27 +21,27 @@ class ResponseFPMTest extends TestCase
     {
         $cookie = 'cookie1=value1';
         $response = $this->client->call(Client::METHOD_GET, '/cookies', ['Cookie: ' . $cookie]);
-        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertSame(200, $response['headers']['status-code']);
         $this->assertEquals($cookie, $response['body']);
 
         $cookie = 'cookie1=value1; cookie2=value2';
         $response = $this->client->call(Client::METHOD_GET, '/cookies', ['Cookie: ' . $cookie]);
-        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertSame(200, $response['headers']['status-code']);
         $this->assertEquals($cookie, $response['body']);
 
         $cookie = 'cookie1=value1;cookie2=value2';
         $response = $this->client->call(Client::METHOD_GET, '/cookies', ['Cookie: ' . $cookie]);
-        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertSame(200, $response['headers']['status-code']);
         $this->assertEquals($cookie, $response['body']);
 
         $cookie = 'cookie1=value1=value2';
         $response = $this->client->call(Client::METHOD_GET, '/cookies', ['Cookie: ' . $cookie]);
-        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertSame(200, $response['headers']['status-code']);
         $this->assertEquals($cookie, $response['body']);
 
         $cookie = 'cookie1=v1; Cookie1=v2';
         $response = $this->client->call(Client::METHOD_GET, '/cookies', ['Cookie: ' . $cookie]);
-        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertSame(200, $response['headers']['status-code']);
         $this->assertEquals($cookie, $response['body']);
     }
 }

--- a/tests/e2e/ResponseSwooleTest.php
+++ b/tests/e2e/ResponseSwooleTest.php
@@ -7,7 +7,7 @@ namespace Utopia\Http\Tests;
 use PHPUnit\Framework\TestCase;
 use Tests\E2E\Client;
 
-class ResponseSwooleTest extends TestCase
+final class ResponseSwooleTest extends TestCase
 {
     use BaseTest;
     protected Client $client;
@@ -22,17 +22,17 @@ class ResponseSwooleTest extends TestCase
         $headers = ['Cookie: cookie1=value1; cookie2=value2'];
 
         $response = $this->client->call(Client::METHOD_GET, '/cookie/cookie1', $headers);
-        $this->assertEquals(200, $response['headers']['status-code']);
-        $this->assertEquals('value1', $response['body']);
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame('value1', $response['body']);
 
         $response = $this->client->call(Client::METHOD_GET, '/cookie/cookie2', $headers);
-        $this->assertEquals(200, $response['headers']['status-code']);
-        $this->assertEquals('value2', $response['body']);
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame('value2', $response['body']);
     }
 
     public function testSwooleResources(): void
     {
         $response = $this->client->call(Client::METHOD_DELETE, '/swoole-test');
-        $this->assertEquals('DELETE', $response['body']);
+        $this->assertSame('DELETE', $response['body']);
     }
 }


### PR DESCRIPTION
## Summary
- Upgrade `phpunit/phpunit` ^9.5 → ^12.0, `phpstan/phpstan` ^2.0 → ^2.1, `rector/rector` ^2.0 → ^2.4 (all pulling the current latest).
- Expand Rector with the PHPUnit 10/11/12, code-quality, and annotations-to-attributes sets; drop three dead skip entries; skip `AssertEmptyNullableObjectToAssertInstanceofRector` which weakens `assertNull`.
- Run the refactor (adds `declare(strict_types=1)` to tests, finalizes test classes, converts the `@dataProvider` to a generator, `assertEquals` → `assertSame` where inferable) and sweep remaining `assertEquals(null|true|false, …)` and literal-expected cases manually.
- Migrate `phpunit.xml` to the PHPUnit 12 schema and exclude the `BaseTest` trait file and the misnamed `UtopiaFPMRequestTest` mock helper from the unit suite (both previously produced runner warnings).

## Noteworthy fixes surfaced by stricter assertions
- `RequestTest::testCanRemoveHeaders` asserted `assertEquals(null, getHeader(...))`, which only passed via `null == ''` loose equality — `getHeader` is typed `string`. Now `assertSame('', …)`.
- `RouteTest::testCanSetAndGetAction` compared two different closures with `assertEquals` — replaced with `assertInstanceOf(\Closure::class, …)`, which is what the test actually meant.

## Test plan
- [x] `composer analyze` (PHPStan level 7) clean
- [x] `composer refactor:check` (Rector dry-run) clean
- [x] `composer format:check` (Pint) clean
- [x] `vendor/bin/phpunit --testsuite unit` — 84 tests, 248 assertions, all pass
- [ ] e2e suites (`e2e-fpm`, `e2e-swoole`) — require docker fixtures, not run locally; CI should exercise them

🤖 Generated with [Claude Code](https://claude.com/claude-code)