### PR TITLE
Fix concurrency races on shared Http/Route singletons

### DIFF
--- a/src/Http/Adapter.php
+++ b/src/Http/Adapter.php
@@ -11,5 +11,21 @@ abstract class Adapter
     abstract public function onStart(callable $callback): void;
     abstract public function onRequest(callable $callback): void;
     abstract public function start(): void;
+
+    /**
+     * Return the global container — the singleton-scoped registry shared
+     * across all requests. Use this for resources that should outlive a
+     * single request (clients, configs, etc.).
+     */
     abstract public function getContainer(): Container;
+
+    /**
+     * Return the per-request context container. Coroutine-local under the
+     * Swoole adapters; identical to getContainer() under FPM. Use this for
+     * values scoped to a single request — request, response, route,
+     * matchedPath, error, etc. Lookups fall through to the global
+     * container's parent chain, so getContext()->get('someSingleton')
+     * still resolves.
+     */
+    abstract public function getContext(): Container;
 }

--- a/src/Http/Adapter.php
+++ b/src/Http/Adapter.php
@@ -13,19 +13,16 @@ abstract class Adapter
     abstract public function start(): void;
 
     /**
-     * Return the global container — the singleton-scoped registry shared
-     * across all requests. Use this for resources that should outlive a
-     * single request (clients, configs, etc.).
-     */
-    abstract public function getContainer(): Container;
-
-    /**
-     * Return the per-request context container. Coroutine-local under the
-     * Swoole adapters; identical to getContainer() under FPM. Use this for
-     * values scoped to a single request — request, response, route,
-     * matchedPath, error, etc. Lookups fall through to the global
-     * container's parent chain, so getContext()->get('someSingleton')
-     * still resolves.
+     * Return the container for the current execution context:
+     *
+     * - Inside a request, the per-request container (coroutine-local
+     *   under the Swoole adapters), with parent-chain fallback to the
+     *   global container — so singleton lookups still resolve.
+     * - Outside a request (boot, onStart hooks), the global container
+     *   directly.
+     *
+     * Callers don't need to know which "scope" they're in; they get
+     * the right container for where they are.
      */
     abstract public function getContext(): Container;
 }

--- a/src/Http/Adapter.php
+++ b/src/Http/Adapter.php
@@ -13,16 +13,9 @@ abstract class Adapter
     abstract public function start(): void;
 
     /**
-     * Return the container for the current execution context:
-     *
-     * - Inside a request, the per-request container (coroutine-local
-     *   under the Swoole adapters), with parent-chain fallback to the
-     *   global container — so singleton lookups still resolve.
-     * - Outside a request (boot, onStart hooks), the global container
-     *   directly.
-     *
-     * Callers don't need to know which "scope" they're in; they get
-     * the right container for where they are.
+     * Container for the current execution context: the per-request
+     * container inside a request (coroutine-local under Swoole, with
+     * parent-chain fallback to global), the global container otherwise.
      */
     abstract public function getContext(): Container;
 }

--- a/src/Http/Adapter/FPM/Server.php
+++ b/src/Http/Adapter/FPM/Server.php
@@ -30,5 +30,10 @@ class Server extends Adapter
         return $this->container;
     }
 
+    public function getContext(): Container
+    {
+        return $this->container;
+    }
+
     public function start(): void {}
 }

--- a/src/Http/Adapter/FPM/Server.php
+++ b/src/Http/Adapter/FPM/Server.php
@@ -25,11 +25,6 @@ class Server extends Adapter
         \call_user_func($callback, $this);
     }
 
-    public function getContainer(): Container
-    {
-        return $this->container;
-    }
-
     public function getContext(): Container
     {
         return $this->container;

--- a/src/Http/Adapter/Swoole/Server.php
+++ b/src/Http/Adapter/Swoole/Server.php
@@ -12,7 +12,7 @@ use Utopia\Http\Adapter;
 class Server extends Adapter
 {
     protected SwooleServer $server;
-    protected const string REQUEST_CONTAINER_CONTEXT_KEY = '__utopia_http_request_container';
+    protected const string CONTEXT_KEY = '__utopia_http_context';
     protected Container $container;
 
     /**
@@ -28,11 +28,11 @@ class Server extends Adapter
     public function onRequest(callable $callback): void
     {
         $this->server->on('request', function (SwooleRequest $request, SwooleResponse $response) use ($callback) {
-            $requestContainer = new Container($this->container);
-            $requestContainer->set('swooleRequest', fn() => $request);
-            $requestContainer->set('swooleResponse', fn() => $response);
+            $context = new Container($this->container);
+            $context->set('swooleRequest', fn() => $request);
+            $context->set('swooleResponse', fn() => $response);
 
-            Coroutine::getContext()[self::REQUEST_CONTAINER_CONTEXT_KEY] = $requestContainer;
+            Coroutine::getContext()[self::CONTEXT_KEY] = $context;
 
             \call_user_func($callback, new Request($request), new Response($response));
         });
@@ -41,7 +41,7 @@ class Server extends Adapter
     public function getContainer(): Container
     {
         if (Coroutine::getCid() !== -1) {
-            return Coroutine::getContext()[self::REQUEST_CONTAINER_CONTEXT_KEY] ?? $this->container;
+            return Coroutine::getContext()[self::CONTEXT_KEY] ?? $this->container;
         }
 
         return $this->container;

--- a/src/Http/Adapter/Swoole/Server.php
+++ b/src/Http/Adapter/Swoole/Server.php
@@ -40,6 +40,11 @@ class Server extends Adapter
 
     public function getContainer(): Container
     {
+        return $this->container;
+    }
+
+    public function getContext(): Container
+    {
         if (Coroutine::getCid() !== -1) {
             return Coroutine::getContext()[self::CONTEXT_KEY] ?? $this->container;
         }

--- a/src/Http/Adapter/Swoole/Server.php
+++ b/src/Http/Adapter/Swoole/Server.php
@@ -38,11 +38,6 @@ class Server extends Adapter
         });
     }
 
-    public function getContainer(): Container
-    {
-        return $this->container;
-    }
-
     public function getContext(): Container
     {
         if (Coroutine::getCid() !== -1) {

--- a/src/Http/Adapter/SwooleCoroutine/Server.php
+++ b/src/Http/Adapter/SwooleCoroutine/Server.php
@@ -52,6 +52,11 @@ class Server extends Adapter
 
     public function getContainer(): Container
     {
+        return $this->container;
+    }
+
+    public function getContext(): Container
+    {
         return Coroutine::getContext()[self::CONTEXT_KEY] ?? $this->container;
     }
 

--- a/src/Http/Adapter/SwooleCoroutine/Server.php
+++ b/src/Http/Adapter/SwooleCoroutine/Server.php
@@ -11,7 +11,7 @@ use Utopia\Http\Adapter;
 
 class Server extends Adapter
 {
-    protected const string REQUEST_CONTAINER_CONTEXT_KEY = '__utopia_http_request_container';
+    protected const string CONTEXT_KEY = '__utopia_http_context';
 
     protected SwooleServer $server;
     protected Container $container;
@@ -36,23 +36,23 @@ class Server extends Adapter
     public function onRequest(callable $callback): void
     {
         $this->server->handle('/', function (SwooleRequest $request, SwooleResponse $response) use ($callback) {
-            $requestContainer = new Container($this->container);
-            $requestContainer->set('swooleRequest', fn() => $request);
-            $requestContainer->set('swooleResponse', fn() => $response);
+            $context = new Container($this->container);
+            $context->set('swooleRequest', fn() => $request);
+            $context->set('swooleResponse', fn() => $response);
 
-            Coroutine::getContext()[self::REQUEST_CONTAINER_CONTEXT_KEY] = $requestContainer;
+            Coroutine::getContext()[self::CONTEXT_KEY] = $context;
 
             try {
                 \call_user_func($callback, new Request($request), new Response($response));
             } finally {
-                unset(Coroutine::getContext()[self::REQUEST_CONTAINER_CONTEXT_KEY]);
+                unset(Coroutine::getContext()[self::CONTEXT_KEY]);
             }
         });
     }
 
     public function getContainer(): Container
     {
-        return Coroutine::getContext()[self::REQUEST_CONTAINER_CONTEXT_KEY] ?? $this->container;
+        return Coroutine::getContext()[self::CONTEXT_KEY] ?? $this->container;
     }
 
     public function getServer(): SwooleServer

--- a/src/Http/Adapter/SwooleCoroutine/Server.php
+++ b/src/Http/Adapter/SwooleCoroutine/Server.php
@@ -50,11 +50,6 @@ class Server extends Adapter
         });
     }
 
-    public function getContainer(): Container
-    {
-        return $this->container;
-    }
-
     public function getContext(): Container
     {
         return Coroutine::getContext()[self::CONTEXT_KEY] ?? $this->container;

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -48,6 +48,11 @@ class Http
 
     protected Container $container;
 
+    /**
+     * @deprecated Never assigned by the framework. Per-request state lives
+     * on the adapter's container (coroutine-local under Swoole). Will be
+     * removed in a future major release.
+     */
     protected ?Container $requestContainer = null;
 
     /**

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -606,7 +606,7 @@ class Http
             $match = new RouteMatch($route, '');
             $context->set('match', fn() => $match);
         }
-        $preparedPath = Router::preparePath($match->matchedPath);
+        $preparedPath = Router::preparePath($match->path);
         $pathValues = $route->getPathValues($request, $preparedPath[0]);
 
         try {

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -623,14 +623,7 @@ class Http
             }
 
             if (!$response->isSent()) {
-                $arguments = $this->getArguments($route, $pathValues, $request->getParams());
-
-                $resolved = [];
-                foreach ($route->getParams() as $name => $param) {
-                    $resolved[$name] = $arguments[$param['order']] ?? null;
-                }
-                $match->arguments = $resolved;
-
+                $arguments = $this->getArguments($route, $pathValues, $request->getParams(), $match->arguments);
                 \call_user_func_array($route->getAction(), $arguments);
             }
 
@@ -683,17 +676,17 @@ class Http
     }
 
     /**
-     * Get Arguments
-     *
      * @param  array<string, mixed>  $values
      * @param  array<string, mixed>  $requestParams
+     * @param  array<string, mixed>  $resolved
+     * @param-out array<string, mixed> $resolved
      * @return array<int, mixed>
      * @throws Exception
      */
-    protected function getArguments(Hook $hook, array $values, array $requestParams): array
+    protected function getArguments(Hook $hook, array $values, array $requestParams, array &$resolved = []): array
     {
         $arguments = [];
-        foreach ($hook->getParams() as $key => $param) { // Get value from route or request object
+        foreach ($hook->getParams() as $key => $param) {
             $existsInRequest = \array_key_exists($key, $requestParams);
             $existsInValues = \array_key_exists($key, $values);
             $paramExists = $existsInRequest || $existsInValues;
@@ -703,6 +696,8 @@ class Http
                 $arg = \call_user_func_array($arg, array_values($this->getResources($param['injections'])));
             }
             $value = $existsInValues ? $values[$key] : $arg;
+
+            $resolved[(string) $key] = $value;
 
             if (!$param['skipValidation']) {
                 if (!$paramExists && !$param['optional']) {

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -106,11 +106,14 @@ class Http
     protected static array $requestHooks = [];
 
     /**
-     * Route
-     *
-     * Memory cached result for chosen route
+     * Per-request container keys for the currently matched route and
+     * the prepared-path string it was matched under. Storing these on
+     * the per-request container (which is coroutine-local in the Swoole
+     * adapters) keeps concurrent requests from clobbering each other's
+     * routing state on the shared Http singleton.
      */
-    protected ?Route $route = null;
+    private const string ROUTE_CONTEXT_KEY = '__utopia_http_route';
+    private const string MATCHED_PATH_CONTEXT_KEY = '__utopia_http_matched_path';
 
     /**
      * Wildcard route
@@ -465,17 +468,36 @@ class Http
      */
     public function getRoute(): ?Route
     {
-        return $this->route ?? null;
+        $container = $this->server->getContainer();
+
+        return $container->has(self::ROUTE_CONTEXT_KEY) ? $container->get(self::ROUTE_CONTEXT_KEY) : null;
     }
 
     /**
      * Set the current route
      */
-    public function setRoute(Route $route): self
+    public function setRoute(?Route $route): self
     {
-        $this->route = $route;
+        $this->server->getContainer()->set(self::ROUTE_CONTEXT_KEY, fn() => $route);
 
         return $this;
+    }
+
+    /**
+     * Read the prepared-path string the current request matched under.
+     * Falls back to '' so callers (e.g. tests invoking execute() directly)
+     * keep getting the legacy "first registered path-params" behavior.
+     */
+    private function getMatchedPath(): string
+    {
+        $container = $this->server->getContainer();
+
+        return $container->has(self::MATCHED_PATH_CONTEXT_KEY) ? $container->get(self::MATCHED_PATH_CONTEXT_KEY) : '';
+    }
+
+    private function setMatchedPath(string $path): void
+    {
+        $this->server->getContainer()->set(self::MATCHED_PATH_CONTEXT_KEY, fn() => $path);
     }
 
     /**
@@ -590,8 +612,11 @@ class Http
      */
     public function match(Request $request, bool $fresh = true): ?Route
     {
-        if (null !== $this->route && !$fresh) {
-            return $this->route;
+        if (!$fresh) {
+            $cached = $this->getRoute();
+            if (null !== $cached) {
+                return $cached;
+            }
         }
 
         $url = parse_url($request->getURI(), PHP_URL_PATH);
@@ -599,9 +624,18 @@ class Http
         $method = $request->getMethod();
         $method = (self::REQUEST_METHOD_HEAD === $method) ? self::REQUEST_METHOD_GET : $method;
 
-        $this->route = Router::match($method, $url);
+        $matched = Router::match($method, $url);
+        if (null === $matched) {
+            $this->setRoute(null);
+            $this->setMatchedPath('');
+            return null;
+        }
 
-        return $this->route;
+        [$route, $matchedPath] = $matched;
+        $this->setRoute($route);
+        $this->setMatchedPath($matchedPath);
+
+        return $route;
     }
 
     /**
@@ -612,7 +646,7 @@ class Http
         $arguments = [];
         $groups = $route->getGroups();
 
-        $preparedPath = Router::preparePath($route->getMatchedPath());
+        $preparedPath = Router::preparePath($this->getMatchedPath());
         $pathValues = $route->getPathValues($request, $preparedPath[0]);
 
         try {
@@ -719,7 +753,6 @@ class Http
                 }
             }
 
-            $hook->setParamValue($key, $value);
             $arguments[$param['order']] = $value;
         }
 
@@ -747,7 +780,7 @@ class Http
         $attributes = [
             'url.scheme' => $request->getProtocol(),
             'http.request.method' => $request->getMethod(),
-            'http.route' => $this->route?->getPath(),
+            'http.route' => $this->getRoute()?->getPath(),
             'http.response.status_code' => $response->getStatusCode(),
         ];
         $this->requestDuration->record($requestDuration, $attributes);
@@ -854,12 +887,14 @@ class Http
         }
 
         if (null === $route && null !== self::$wildcardRoute) {
-            $route = self::$wildcardRoute;
-            $this->route = $route;
+            // Clone so we can stamp the request URI onto $path without
+            // mutating the singleton shared across concurrent coroutines.
+            $route = clone self::$wildcardRoute;
             $path = parse_url($request->getURI(), PHP_URL_PATH);
             $path = \is_string($path) ? ($path === '' ? '/' : $path) : '/';
             $route->path($path);
 
+            $this->setRoute($route);
             $this->setRequestResource('route', fn() => $route, []);
         }
         if (null !== $route) {

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -787,6 +787,11 @@ class Http
 
         $this->setContext('request', fn() => $request);
         $this->setContext('response', fn() => $response);
+        // Seed 'match' to null up front so requestHooks, the global error
+        // path, and any pre-routing code can read it without tripping the
+        // "Failed to find resource" error from getResource('match'). It
+        // gets overwritten with the real RouteMatch once match() runs.
+        $this->setContext('match', fn() => null);
 
         try {
             foreach (self::$requestHooks as $hook) {

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -584,14 +584,6 @@ class Http
         $method = (self::REQUEST_METHOD_HEAD === $method) ? self::REQUEST_METHOD_GET : $method;
 
         $match = Router::match($method, $url);
-        if ($match !== null) {
-            // Seed arguments with path values right away so init hooks
-            // can read URI segments (e.g. {databaseId}, {fileId}) via
-            // $match->arguments. execute() replaces this with the full
-            // resolved+validated set right before the action runs.
-            $pathValues = $match->route->getPathValues($request, $match->path);
-            $match = new RouteMatch($match->route, $match->path, $pathValues);
-        }
         $context->set('match', fn() => $match);
 
         return $match?->route;
@@ -611,9 +603,7 @@ class Http
             // execute() called directly (e.g. from a test) without a prior
             // match() — synthesize a RouteMatch so shutdown / error hooks
             // injecting 'match' still see the route they're running under.
-            // Seed arguments with path values for the same reason match()
-            // does: init hooks need URI segments before the action runs.
-            $match = new RouteMatch($route, '', $route->getPathValues($request, ''));
+            $match = new RouteMatch($route, '');
             $context->set('match', fn() => $match);
         }
         $preparedPath = Router::preparePath($match->path);

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -571,10 +571,10 @@ class Http
     {
         $context = $this->server->getContext();
 
-        if (!$fresh && $context->has('route')) {
-            $cached = $context->get('route');
-            if (null !== $cached) {
-                return $cached;
+        if (!$fresh && $context->has('match')) {
+            $cached = $context->get('match');
+            if ($cached instanceof RouteMatch) {
+                return $cached->route;
             }
         }
 
@@ -583,18 +583,10 @@ class Http
         $method = $request->getMethod();
         $method = (self::REQUEST_METHOD_HEAD === $method) ? self::REQUEST_METHOD_GET : $method;
 
-        $matched = Router::match($method, $url);
-        if (null === $matched) {
-            $context->set('route', fn() => null);
-            $context->set('matchedPath', fn() => '');
-            return null;
-        }
+        $match = Router::match($method, $url);
+        $context->set('match', fn() => $match);
 
-        [$route, $matchedPath] = $matched;
-        $context->set('route', fn() => $route);
-        $context->set('matchedPath', fn() => $matchedPath);
-
-        return $route;
+        return $match?->route;
     }
 
     /**
@@ -606,8 +598,15 @@ class Http
         $groups = $route->getGroups();
 
         $context = $this->server->getContext();
-        $matchedPath = $context->has('matchedPath') ? $context->get('matchedPath') : '';
-        $preparedPath = Router::preparePath($matchedPath);
+        $match = $context->has('match') ? $context->get('match') : null;
+        if (!$match instanceof RouteMatch || $match->route !== $route) {
+            // execute() called directly (e.g. from a test) without a prior
+            // match() — synthesize a RouteMatch so shutdown / error hooks
+            // injecting 'match' still see the route they're running under.
+            $match = new RouteMatch($route, '');
+            $context->set('match', fn() => $match);
+        }
+        $preparedPath = Router::preparePath($match->matchedPath);
         $pathValues = $route->getPathValues($request, $preparedPath[0]);
 
         try {
@@ -632,16 +631,17 @@ class Http
             if (!$response->isSent()) {
                 $arguments = $this->getArguments($route, $pathValues, $request->getParams());
 
-                // Stash a name-keyed map of the route's resolved+validated
-                // params on the context so shutdown / error hooks can read
-                // the same values the action saw — e.g. for label
+                // Update the per-request RouteMatch with the resolved+
+                // validated argument map so shutdown / error hooks can
+                // read the same values the action saw — e.g. for label
                 // substitution like {request.fileId}. Race-free because
                 // the context container is per-request.
                 $resolved = [];
                 foreach ($route->getParams() as $name => $param) {
                     $resolved[$name] = $arguments[$param['order']] ?? null;
                 }
-                $this->setContext('arguments', fn() => $resolved);
+                $match = $match->withArguments($resolved);
+                $this->setContext('match', fn() => $match);
 
                 \call_user_func_array($route->getAction(), $arguments);
             }
@@ -751,11 +751,11 @@ class Http
 
         $requestDuration = microtime(true) - $start;
         $context = $this->server->getContext();
-        $route = $context->has('route') ? $context->get('route') : null;
+        $match = $context->has('match') ? $context->get('match') : null;
         $attributes = [
             'url.scheme' => $request->getProtocol(),
             'http.request.method' => $request->getMethod(),
-            'http.route' => $route?->getPath(),
+            'http.route' => $match instanceof RouteMatch ? $match->route->getPath() : null,
             'http.response.status_code' => $response->getStatusCode(),
         ];
         $this->requestDuration->record($requestDuration, $attributes);
@@ -824,8 +824,6 @@ class Http
         $route = $this->match($request);
         $groups = ($route instanceof Route) ? $route->getGroups() : [];
 
-        $this->setContext('route', fn() => $route, []);
-
         if (self::REQUEST_METHOD_HEAD === $method) {
             $method = self::REQUEST_METHOD_GET;
             $response->disablePayload();
@@ -869,7 +867,8 @@ class Http
             $path = \is_string($path) ? ($path === '' ? '/' : $path) : '/';
             $route->path($path);
 
-            $this->setContext('route', fn() => $route);
+            $match = new RouteMatch($route, '');
+            $this->setContext('match', fn() => $match);
         }
         if (null !== $route) {
             return $this->execute($route, $request, $response);

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -363,7 +363,7 @@ class Http
     public function getResource(string $name): mixed
     {
         try {
-            return $this->server->getContainer()->get($name);
+            return $this->server->getContext()->get($name);
         } catch (ContainerExceptionInterface|NotFoundExceptionInterface $e) {
             // Normalize DI container errors to the Http layer's "resource" terminology.
             $message = str_replace('dependency', 'resource', $e->getMessage());
@@ -418,7 +418,7 @@ class Http
      */
     protected function setContext(string $name, callable $callback, array $injections = []): void
     {
-        $this->server->getContainer()->set($name, $callback, $injections);
+        $this->server->getContext()->set($name, $callback, $injections);
     }
 
     /**
@@ -569,7 +569,7 @@ class Http
      */
     public function match(Request $request, bool $fresh = true): ?Route
     {
-        $context = $this->server->getContainer();
+        $context = $this->server->getContext();
 
         if (!$fresh && $context->has('route')) {
             $cached = $context->get('route');
@@ -605,7 +605,7 @@ class Http
         $arguments = [];
         $groups = $route->getGroups();
 
-        $context = $this->server->getContainer();
+        $context = $this->server->getContext();
         $matchedPath = $context->has('matchedPath') ? $context->get('matchedPath') : '';
         $preparedPath = Router::preparePath($matchedPath);
         $pathValues = $route->getPathValues($request, $preparedPath[0]);
@@ -738,7 +738,7 @@ class Http
         $result = $this->runInternal($request, $response);
 
         $requestDuration = microtime(true) - $start;
-        $context = $this->server->getContainer();
+        $context = $this->server->getContext();
         $route = $context->has('route') ? $context->get('route') : null;
         $attributes = [
             'url.scheme' => $request->getProtocol(),

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -631,6 +631,18 @@ class Http
 
             if (!$response->isSent()) {
                 $arguments = $this->getArguments($route, $pathValues, $request->getParams());
+
+                // Stash a name-keyed map of the route's resolved+validated
+                // params on the context so shutdown / error hooks can read
+                // the same values the action saw — e.g. for label
+                // substitution like {request.fileId}. Race-free because
+                // the context container is per-request.
+                $resolved = [];
+                foreach ($route->getParams() as $name => $param) {
+                    $resolved[$name] = $arguments[$param['order']] ?? null;
+                }
+                $this->setContext('arguments', fn() => $resolved);
+
                 \call_user_func_array($route->getAction(), $arguments);
             }
 

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -584,6 +584,14 @@ class Http
         $method = (self::REQUEST_METHOD_HEAD === $method) ? self::REQUEST_METHOD_GET : $method;
 
         $match = Router::match($method, $url);
+        if ($match !== null) {
+            // Seed arguments with path values right away so init hooks
+            // can read URI segments (e.g. {databaseId}, {fileId}) via
+            // $match->arguments. execute() replaces this with the full
+            // resolved+validated set right before the action runs.
+            $pathValues = $match->route->getPathValues($request, $match->path);
+            $match = new RouteMatch($match->route, $match->path, $pathValues);
+        }
         $context->set('match', fn() => $match);
 
         return $match?->route;
@@ -603,7 +611,9 @@ class Http
             // execute() called directly (e.g. from a test) without a prior
             // match() — synthesize a RouteMatch so shutdown / error hooks
             // injecting 'match' still see the route they're running under.
-            $match = new RouteMatch($route, '');
+            // Seed arguments with path values for the same reason match()
+            // does: init hooks need URI segments before the action runs.
+            $match = new RouteMatch($route, '', $route->getPathValues($request, ''));
             $context->set('match', fn() => $match);
         }
         $preparedPath = Router::preparePath($match->path);

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -136,11 +136,7 @@ class Http
         date_default_timezone_set($timezone);
         $this->files = new Files();
         $this->server = $server;
-        // Capture the global container at construction. INVARIANT: `Http`
-        // is constructed at boot, never inside a request. With no
-        // coroutine active, getContext() returns the global container
-        // directly — so this capture is stable for the lifetime of the
-        // Http instance.
+        // Captures the global container; assumes Http is constructed at boot, not inside a request.
         $this->container = $server->getContext();
         $this->setTelemetry(new NoTelemetry());
     }
@@ -411,13 +407,8 @@ class Http
     }
 
     /**
-     * Set a request-scoped value on the current request's context container.
-     *
-     * The framework convention is: `setResource()` registers singletons on
-     * the global container; `setContext()` registers per-request values on
-     * the adapter's request container, which is coroutine-local under the
-     * Swoole adapters. `getResource()` reads from the request container
-     * with parent-fallback to the global one, so either kind resolves.
+     * Register a per-request value on the context container.
+     * Counterpart to setResource() for global singletons.
      *
      * @param list<string> $injections
      */
@@ -605,9 +596,7 @@ class Http
         $context = $this->server->getContext();
         $match = $context->has('match') ? $context->get('match') : null;
         if (!$match instanceof RouteMatch || $match->route !== $route) {
-            // execute() called directly (e.g. from a test) without a prior
-            // match() — synthesize a RouteMatch so shutdown / error hooks
-            // injecting 'match' still see the route they're running under.
+            // execute() called directly without a prior match().
             $match = new RouteMatch($route, '');
             $context->set('match', fn() => $match);
         }
@@ -636,11 +625,6 @@ class Http
             if (!$response->isSent()) {
                 $arguments = $this->getArguments($route, $pathValues, $request->getParams());
 
-                // Update the per-request RouteMatch with the resolved+
-                // validated argument map so shutdown / error hooks can
-                // read the same values the action saw — e.g. for label
-                // substitution like {request.fileId}. Race-free because
-                // the context container is per-request.
                 $resolved = [];
                 foreach ($route->getParams() as $name => $param) {
                     $resolved[$name] = $arguments[$param['order']] ?? null;
@@ -791,10 +775,6 @@ class Http
 
         $this->setContext('request', fn() => $request);
         $this->setContext('response', fn() => $response);
-        // Seed 'match' to null up front so requestHooks, the global error
-        // path, and any pre-routing code can read it without tripping the
-        // "Failed to find resource" error from getResource('match'). It
-        // gets overwritten with the real RouteMatch once match() runs.
         $this->setContext('match', fn() => null);
 
         try {
@@ -869,8 +849,7 @@ class Http
         }
 
         if (null === $route && null !== self::$wildcardRoute) {
-            // Clone so we can stamp the request URI onto $path without
-            // mutating the singleton shared across concurrent coroutines.
+            // Clone before stamping $path so concurrent coroutines don't fight over the singleton.
             $route = clone self::$wildcardRoute;
             $path = parse_url($request->getURI(), PHP_URL_PATH);
             $path = \is_string($path) ? ($path === '' ? '/' : $path) : '/';

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -406,11 +406,17 @@ class Http
     }
 
     /**
-     * Set a request-scoped resource on the current request's container.
+     * Set a request-scoped value on the current request's context container.
+     *
+     * The framework convention is: `setResource()` registers singletons on
+     * the global container; `setContext()` registers per-request values on
+     * the adapter's request container, which is coroutine-local under the
+     * Swoole adapters. `getResource()` reads from the request container
+     * with parent-fallback to the global one, so either kind resolves.
      *
      * @param list<string> $injections
      */
-    protected function setRequestResource(string $name, callable $callback, array $injections = []): void
+    protected function setContext(string $name, callable $callback, array $injections = []): void
     {
         $this->server->getContainer()->set($name, $callback, $injections);
     }
@@ -674,7 +680,7 @@ class Http
                 }
             }
         } catch (\Throwable $e) {
-            $this->setRequestResource('error', fn() => $e, []);
+            $this->setContext('error', fn() => $e, []);
 
             foreach ($groups as $group) {
                 foreach (self::$errors as $error) { // Group error hooks
@@ -793,8 +799,8 @@ class Http
             $response->setCompressionSupported($this->compressionSupported);
         }
 
-        $this->setRequestResource('request', fn() => $request);
-        $this->setRequestResource('response', fn() => $response);
+        $this->setContext('request', fn() => $request);
+        $this->setContext('response', fn() => $response);
 
         try {
             foreach (self::$requestHooks as $hook) {
@@ -802,7 +808,7 @@ class Http
                 \call_user_func_array($hook->getAction(), $arguments);
             }
         } catch (\Exception $e) {
-            $this->setRequestResource('error', fn() => $e, []);
+            $this->setContext('error', fn() => $e, []);
 
             foreach (self::$errors as $error) { // Global error hooks
                 if (\in_array('*', $error->getGroups())) {
@@ -832,7 +838,7 @@ class Http
         $route = $this->match($request);
         $groups = ($route instanceof Route) ? $route->getGroups() : [];
 
-        $this->setRequestResource('route', fn() => $route, []);
+        $this->setContext('route', fn() => $route, []);
 
         if (self::REQUEST_METHOD_HEAD === $method) {
             $method = self::REQUEST_METHOD_GET;
@@ -860,7 +866,7 @@ class Http
                 foreach (self::$errors as $error) { // Global error hooks
                     /** @var Hook $error */
                     if (\in_array('*', $error->getGroups())) {
-                        $this->setRequestResource('error', fn() => $e, []);
+                        $this->setContext('error', fn() => $e, []);
                         \call_user_func_array($error->getAction(), $this->getArguments($error, [], $request->getParams()));
                     }
                 }
@@ -878,7 +884,7 @@ class Http
             $route->path($path);
 
             $this->setRoute($route);
-            $this->setRequestResource('route', fn() => $route, []);
+            $this->setContext('route', fn() => $route, []);
         }
         if (null !== $route) {
             return $this->execute($route, $request, $response);
@@ -902,7 +908,7 @@ class Http
             } catch (\Throwable $e) {
                 foreach (self::$errors as $error) { // Global error hooks
                     if (\in_array('*', $error->getGroups())) {
-                        $this->setRequestResource('error', fn() => $e, []);
+                        $this->setContext('error', fn() => $e, []);
                         \call_user_func_array($error->getAction(), $this->getArguments($error, [], $request->getParams()));
                     }
                 }
@@ -910,7 +916,7 @@ class Http
         } else {
             foreach (self::$errors as $error) { // Global error hooks
                 if (\in_array('*', $error->getGroups())) {
-                    $this->setRequestResource('error', fn() => new Exception('Not Found', 404), []);
+                    $this->setContext('error', fn() => new Exception('Not Found', 404), []);
                     \call_user_func_array($error->getAction(), $this->getArguments($error, [], $request->getParams()));
                 }
             }

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -136,7 +136,12 @@ class Http
         date_default_timezone_set($timezone);
         $this->files = new Files();
         $this->server = $server;
-        $this->container = $server->getContainer();
+        // Capture the global container at construction. INVARIANT: `Http`
+        // is constructed at boot, never inside a request. With no
+        // coroutine active, getContext() returns the global container
+        // directly — so this capture is stable for the lifetime of the
+        // Http instance.
+        $this->container = $server->getContext();
         $this->setTelemetry(new NoTelemetry());
     }
 
@@ -416,7 +421,7 @@ class Http
      *
      * @param list<string> $injections
      */
-    protected function setContext(string $name, callable $callback, array $injections = []): void
+    public function setContext(string $name, callable $callback, array $injections = []): void
     {
         $this->server->getContext()->set($name, $callback, $injections);
     }

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -461,14 +461,9 @@ class Http
         return $container->has('route') ? $container->get('route') : null;
     }
 
-    /**
-     * Set the current route
-     */
-    public function setRoute(?Route $route): self
+    private function setRoute(?Route $route): void
     {
         $this->server->getContainer()->set('route', fn() => $route);
-
-        return $this;
     }
 
     /**

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -49,13 +49,6 @@ class Http
     protected Container $container;
 
     /**
-     * @deprecated Never assigned by the framework. Per-request state lives
-     * on the adapter's container (coroutine-local under Swoole). Will be
-     * removed in a future major release.
-     */
-    protected ?Container $requestContainer = null;
-
-    /**
      * Current running mode
      */
     protected static string $mode = '';

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -458,38 +458,6 @@ class Http
     }
 
     /**
-     * Get the current route
-     */
-    public function getRoute(): ?Route
-    {
-        $container = $this->server->getContainer();
-
-        return $container->has('route') ? $container->get('route') : null;
-    }
-
-    private function setRoute(?Route $route): void
-    {
-        $this->server->getContainer()->set('route', fn() => $route);
-    }
-
-    /**
-     * Read the prepared-path string the current request matched under.
-     * Falls back to '' so callers (e.g. tests invoking execute() directly)
-     * keep getting the legacy "first registered path-params" behavior.
-     */
-    private function getMatchedPath(): string
-    {
-        $container = $this->server->getContainer();
-
-        return $container->has('matchedPath') ? $container->get('matchedPath') : '';
-    }
-
-    private function setMatchedPath(string $path): void
-    {
-        $this->server->getContainer()->set('matchedPath', fn() => $path);
-    }
-
-    /**
      * Add Route
      *
      * Add routing route method, path and callback
@@ -601,8 +569,10 @@ class Http
      */
     public function match(Request $request, bool $fresh = true): ?Route
     {
-        if (!$fresh) {
-            $cached = $this->getRoute();
+        $context = $this->server->getContainer();
+
+        if (!$fresh && $context->has('route')) {
+            $cached = $context->get('route');
             if (null !== $cached) {
                 return $cached;
             }
@@ -615,14 +585,14 @@ class Http
 
         $matched = Router::match($method, $url);
         if (null === $matched) {
-            $this->setRoute(null);
-            $this->setMatchedPath('');
+            $context->set('route', fn() => null);
+            $context->set('matchedPath', fn() => '');
             return null;
         }
 
         [$route, $matchedPath] = $matched;
-        $this->setRoute($route);
-        $this->setMatchedPath($matchedPath);
+        $context->set('route', fn() => $route);
+        $context->set('matchedPath', fn() => $matchedPath);
 
         return $route;
     }
@@ -635,7 +605,9 @@ class Http
         $arguments = [];
         $groups = $route->getGroups();
 
-        $preparedPath = Router::preparePath($this->getMatchedPath());
+        $context = $this->server->getContainer();
+        $matchedPath = $context->has('matchedPath') ? $context->get('matchedPath') : '';
+        $preparedPath = Router::preparePath($matchedPath);
         $pathValues = $route->getPathValues($request, $preparedPath[0]);
 
         try {
@@ -766,10 +738,12 @@ class Http
         $result = $this->runInternal($request, $response);
 
         $requestDuration = microtime(true) - $start;
+        $context = $this->server->getContainer();
+        $route = $context->has('route') ? $context->get('route') : null;
         $attributes = [
             'url.scheme' => $request->getProtocol(),
             'http.request.method' => $request->getMethod(),
-            'http.route' => $this->getRoute()?->getPath(),
+            'http.route' => $route?->getPath(),
             'http.response.status_code' => $response->getStatusCode(),
         ];
         $this->requestDuration->record($requestDuration, $attributes);
@@ -883,8 +857,7 @@ class Http
             $path = \is_string($path) ? ($path === '' ? '/' : $path) : '/';
             $route->path($path);
 
-            $this->setRoute($route);
-            $this->setContext('route', fn() => $route, []);
+            $this->setContext('route', fn() => $route);
         }
         if (null !== $route) {
             return $this->execute($route, $request, $response);

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -104,16 +104,6 @@ class Http
     protected static array $requestHooks = [];
 
     /**
-     * Per-request container keys for the currently matched route and
-     * the prepared-path string it was matched under. Storing these on
-     * the per-request container (which is coroutine-local in the Swoole
-     * adapters) keeps concurrent requests from clobbering each other's
-     * routing state on the shared Http singleton.
-     */
-    private const string ROUTE_CONTEXT_KEY = '__utopia_http_route';
-    private const string MATCHED_PATH_CONTEXT_KEY = '__utopia_http_matched_path';
-
-    /**
      * Wildcard route
      * If set, this get's executed if no other route is matched
      */
@@ -468,7 +458,7 @@ class Http
     {
         $container = $this->server->getContainer();
 
-        return $container->has(self::ROUTE_CONTEXT_KEY) ? $container->get(self::ROUTE_CONTEXT_KEY) : null;
+        return $container->has('route') ? $container->get('route') : null;
     }
 
     /**
@@ -476,7 +466,7 @@ class Http
      */
     public function setRoute(?Route $route): self
     {
-        $this->server->getContainer()->set(self::ROUTE_CONTEXT_KEY, fn() => $route);
+        $this->server->getContainer()->set('route', fn() => $route);
 
         return $this;
     }
@@ -490,12 +480,12 @@ class Http
     {
         $container = $this->server->getContainer();
 
-        return $container->has(self::MATCHED_PATH_CONTEXT_KEY) ? $container->get(self::MATCHED_PATH_CONTEXT_KEY) : '';
+        return $container->has('matchedPath') ? $container->get('matchedPath') : '';
     }
 
     private function setMatchedPath(string $path): void
     {
-        $this->server->getContainer()->set(self::MATCHED_PATH_CONTEXT_KEY, fn() => $path);
+        $this->server->getContainer()->set('matchedPath', fn() => $path);
     }
 
     /**

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -650,8 +650,7 @@ class Http
                 foreach ($route->getParams() as $name => $param) {
                     $resolved[$name] = $arguments[$param['order']] ?? null;
                 }
-                $match = new RouteMatch($match->route, $match->path, $resolved);
-                $this->setContext('match', fn() => $match);
+                $match->arguments = $resolved;
 
                 \call_user_func_array($route->getAction(), $arguments);
             }

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -640,7 +640,7 @@ class Http
                 foreach ($route->getParams() as $name => $param) {
                     $resolved[$name] = $arguments[$param['order']] ?? null;
                 }
-                $match = $match->withArguments($resolved);
+                $match = new RouteMatch($match->route, $match->path, $resolved);
                 $this->setContext('match', fn() => $match);
 
                 \call_user_func_array($route->getAction(), $arguments);

--- a/src/Http/Route.php
+++ b/src/Http/Route.php
@@ -48,12 +48,23 @@ class Route extends Hook
         $this->order = ++self::$counter;
     }
 
+    /**
+     * @deprecated No longer used by the framework. The matched-path string
+     * is returned alongside the Route from Router::match() instead, so the
+     * shared Route singleton is not mutated per request. Will be removed
+     * in a future major release.
+     */
     public function setMatchedPath(string $path): self
     {
         $this->matchedPath = $path;
         return $this;
     }
 
+    /**
+     * @deprecated No longer populated by Router::match(). Read the matched
+     * path from the second element of Router::match()'s return tuple
+     * instead. Will be removed in a future major release.
+     */
     public function getMatchedPath(): string
     {
         return $this->matchedPath;

--- a/src/Http/Route.php
+++ b/src/Http/Route.php
@@ -38,36 +38,12 @@ class Route extends Hook
      */
     protected int $order;
 
-    protected string $matchedPath = '';
-
     public function __construct(string $method, string $path)
     {
         parent::__construct();
         $this->path($path);
         $this->method = $method;
         $this->order = ++self::$counter;
-    }
-
-    /**
-     * @deprecated No longer used by the framework. The matched-path string
-     * is returned alongside the Route from Router::match() instead, so the
-     * shared Route singleton is not mutated per request. Will be removed
-     * in a future major release.
-     */
-    public function setMatchedPath(string $path): self
-    {
-        $this->matchedPath = $path;
-        return $this;
-    }
-
-    /**
-     * @deprecated No longer populated by Router::match(). Read the matched
-     * path from the second element of Router::match()'s return tuple
-     * instead. Will be removed in a future major release.
-     */
-    public function getMatchedPath(): string
-    {
-        return $this->matchedPath;
     }
 
     /**

--- a/src/Http/RouteMatch.php
+++ b/src/Http/RouteMatch.php
@@ -25,17 +25,4 @@ final class RouteMatch
         public readonly string $path,
         public readonly array $arguments = [],
     ) {}
-
-    /**
-     * Return a copy of this match with the resolved-argument map replaced.
-     * Used by the framework once the action's parameters have been
-     * validated, so subsequent shutdown / error hooks can read the same
-     * values the action received.
-     *
-     * @param array<string, mixed> $arguments
-     */
-    public function withArguments(array $arguments): self
-    {
-        return new self($this->route, $this->path, $arguments);
-    }
 }

--- a/src/Http/RouteMatch.php
+++ b/src/Http/RouteMatch.php
@@ -5,23 +5,13 @@ declare(strict_types=1);
 namespace Utopia\Http;
 
 /**
- * Bundle of everything the framework knows about how the current request
- * was routed: the matched Route, the prepared-path key it was matched
- * under (`$path`, with placeholders like ":::") and the name-keyed map
- * of resolved argument values.
+ * Routing state for the current request: the matched Route, the
+ * prepared-path key it matched under (placeholders → ":::"), and the
+ * resolved+validated argument map. `$arguments` is empty until
+ * `Http::execute()` writes it just before the route action runs;
+ * available to the action and downstream shutdown / error hooks.
  *
- * `$route` and `$path` are immutable. `$arguments` starts empty and is
- * written by the framework once — right before the route action runs,
- * after `getArguments()` has resolved and validated the action's
- * parameters. From that point on (action body, shutdown hooks, error
- * hooks) it holds the same values the action received.
- *
- * Init hooks run *before* this write, so they see `$arguments === []`.
- * The mutable property is safe because the RouteMatch lives on the
- * per-request context container (coroutine-local under the Swoole
- * adapters), so only the request's own coroutine touches it.
- *
- * Inject it into a hook or action with `->inject('match')`.
+ * Inject with `->inject('match')`.
  */
 final class RouteMatch
 {

--- a/src/Http/RouteMatch.php
+++ b/src/Http/RouteMatch.php
@@ -7,9 +7,9 @@ namespace Utopia\Http;
 /**
  * Immutable bundle of everything the framework knows about how the current
  * request was routed: the matched Route, the prepared-path key it was
- * matched under (with placeholders like ":::") and — once the action has
- * resolved its parameters — the name-keyed map of resolved + validated
- * argument values.
+ * matched under (`$path`, with placeholders like ":::") and — once the
+ * action has resolved its parameters — the name-keyed map of resolved +
+ * validated argument values.
  *
  * Lives on the per-request context container (coroutine-local under the
  * Swoole adapters) under the key `'match'`. Inject it into a hook or
@@ -22,7 +22,7 @@ final class RouteMatch
      */
     public function __construct(
         public readonly Route $route,
-        public readonly string $matchedPath,
+        public readonly string $path,
         public readonly array $arguments = [],
     ) {}
 
@@ -36,6 +36,6 @@ final class RouteMatch
      */
     public function withArguments(array $arguments): self
     {
-        return new self($this->route, $this->matchedPath, $arguments);
+        return new self($this->route, $this->path, $arguments);
     }
 }

--- a/src/Http/RouteMatch.php
+++ b/src/Http/RouteMatch.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utopia\Http;
+
+/**
+ * Immutable bundle of everything the framework knows about how the current
+ * request was routed: the matched Route, the prepared-path key it was
+ * matched under (with placeholders like ":::") and — once the action has
+ * resolved its parameters — the name-keyed map of resolved + validated
+ * argument values.
+ *
+ * Lives on the per-request context container (coroutine-local under the
+ * Swoole adapters) under the key `'match'`. Inject it into a hook or
+ * action with `->inject('match')`.
+ */
+final class RouteMatch
+{
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    public function __construct(
+        public readonly Route $route,
+        public readonly string $matchedPath,
+        public readonly array $arguments = [],
+    ) {}
+
+    /**
+     * Return a copy of this match with the resolved-argument map replaced.
+     * Used by the framework once the action's parameters have been
+     * validated, so subsequent shutdown / error hooks can read the same
+     * values the action received.
+     *
+     * @param array<string, mixed> $arguments
+     */
+    public function withArguments(array $arguments): self
+    {
+        return new self($this->route, $this->matchedPath, $arguments);
+    }
+}

--- a/src/Http/RouteMatch.php
+++ b/src/Http/RouteMatch.php
@@ -5,15 +5,19 @@ declare(strict_types=1);
 namespace Utopia\Http;
 
 /**
- * Immutable bundle of everything the framework knows about how the current
- * request was routed: the matched Route, the prepared-path key it was
- * matched under (`$path`, with placeholders like ":::") and — once the
- * action has resolved its parameters — the name-keyed map of resolved +
- * validated argument values.
+ * Bundle of everything the framework knows about how the current request
+ * was routed: the matched Route, the prepared-path key it was matched
+ * under (`$path`, with placeholders like ":::") and the name-keyed map
+ * of argument values for the current phase.
  *
- * Lives on the per-request context container (coroutine-local under the
- * Swoole adapters) under the key `'match'`. Inject it into a hook or
- * action with `->inject('match')`.
+ * `$route` and `$path` are immutable. `$arguments` is filled in two
+ * passes during a request — path values at match-time so init hooks can
+ * read them, then the full resolved+validated set right before the
+ * action runs — and is therefore mutable. Safe because the RouteMatch
+ * lives on the per-request context container (coroutine-local under
+ * the Swoole adapters), so only the request's own coroutine touches it.
+ *
+ * Inject it into a hook or action with `->inject('match')`.
  */
 final class RouteMatch
 {
@@ -23,6 +27,6 @@ final class RouteMatch
     public function __construct(
         public readonly Route $route,
         public readonly string $path,
-        public readonly array $arguments = [],
+        public array $arguments = [],
     ) {}
 }

--- a/src/Http/RouteMatch.php
+++ b/src/Http/RouteMatch.php
@@ -8,14 +8,18 @@ namespace Utopia\Http;
  * Bundle of everything the framework knows about how the current request
  * was routed: the matched Route, the prepared-path key it was matched
  * under (`$path`, with placeholders like ":::") and the name-keyed map
- * of argument values for the current phase.
+ * of resolved argument values.
  *
- * `$route` and `$path` are immutable. `$arguments` is filled in two
- * passes during a request — path values at match-time so init hooks can
- * read them, then the full resolved+validated set right before the
- * action runs — and is therefore mutable. Safe because the RouteMatch
- * lives on the per-request context container (coroutine-local under
- * the Swoole adapters), so only the request's own coroutine touches it.
+ * `$route` and `$path` are immutable. `$arguments` starts empty and is
+ * written by the framework once — right before the route action runs,
+ * after `getArguments()` has resolved and validated the action's
+ * parameters. From that point on (action body, shutdown hooks, error
+ * hooks) it holds the same values the action received.
+ *
+ * Init hooks run *before* this write, so they see `$arguments === []`.
+ * The mutable property is safe because the RouteMatch lives on the
+ * per-request context container (coroutine-local under the Swoole
+ * adapters), so only the request's own coroutine touches it.
  *
  * Inject it into a hook or action with `->inject('match')`.
  */

--- a/src/Http/RouteMatch.php
+++ b/src/Http/RouteMatch.php
@@ -15,12 +15,17 @@ namespace Utopia\Http;
  */
 final class RouteMatch
 {
+    /** @var array<string, mixed> */
+    public array $arguments;
+
     /**
      * @param array<string, mixed> $arguments
      */
     public function __construct(
         public readonly Route $route,
         public readonly string $path,
-        public array $arguments = [],
-    ) {}
+        array $arguments = [],
+    ) {
+        $this->arguments = $arguments;
+    }
 }

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -106,15 +106,14 @@ class Router
     }
 
     /**
-     * Match route against the method and path.
+     * Match a request against the registered routes.
      *
-     * Returns the matched Route together with the prepared-path key it was
-     * found under, so callers can resolve path params without mutating the
-     * shared Route singleton.
-     *
-     * @return array{0: Route, 1: string}|null
+     * Returns a RouteMatch holding the matched Route and the prepared-path
+     * key it was found under (placeholders replaced with `:::`), so callers
+     * can resolve path params without mutating the shared Route singleton.
+     * Returns null when no route matches.
      */
-    public static function match(string $method, string $path): ?array
+    public static function match(string $method, string $path): ?RouteMatch
     {
         if (!\array_key_exists($method, self::$routes)) {
             return null;
@@ -135,7 +134,7 @@ class Router
             );
 
             if (\array_key_exists($match, self::$routes[$method])) {
-                return [self::$routes[$method][$match], $match];
+                return new RouteMatch(self::$routes[$method][$match], $match);
             }
         }
 
@@ -144,7 +143,7 @@ class Router
          */
         $match = self::WILDCARD_TOKEN;
         if (\array_key_exists($match, self::$routes[$method])) {
-            return [self::$routes[$method][$match], $match];
+            return new RouteMatch(self::$routes[$method][$match], $match);
         }
 
         /**
@@ -154,7 +153,7 @@ class Router
             $current = ($current ?? '') . "{$part}/";
             $match = $current . self::WILDCARD_TOKEN;
             if (\array_key_exists($match, self::$routes[$method])) {
-                return [self::$routes[$method][$match], $match];
+                return new RouteMatch(self::$routes[$method][$match], $match);
             }
         }
 

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -107,8 +107,14 @@ class Router
 
     /**
      * Match route against the method and path.
+     *
+     * Returns the matched Route together with the prepared-path key it was
+     * found under, so callers can resolve path params without mutating the
+     * shared Route singleton.
+     *
+     * @return array{0: Route, 1: string}|null
      */
-    public static function match(string $method, string $path): ?Route
+    public static function match(string $method, string $path): ?array
     {
         if (!\array_key_exists($method, self::$routes)) {
             return null;
@@ -129,9 +135,7 @@ class Router
             );
 
             if (\array_key_exists($match, self::$routes[$method])) {
-                $route = self::$routes[$method][$match];
-                $route->setMatchedPath($match);
-                return $route;
+                return [self::$routes[$method][$match], $match];
             }
         }
 
@@ -140,9 +144,7 @@ class Router
          */
         $match = self::WILDCARD_TOKEN;
         if (\array_key_exists($match, self::$routes[$method])) {
-            $route = self::$routes[$method][$match];
-            $route->setMatchedPath($match);
-            return $route;
+            return [self::$routes[$method][$match], $match];
         }
 
         /**
@@ -152,9 +154,7 @@ class Router
             $current = ($current ?? '') . "{$part}/";
             $match = $current . self::WILDCARD_TOKEN;
             if (\array_key_exists($match, self::$routes[$method])) {
-                $route = self::$routes[$method][$match];
-                $route->setMatchedPath($match);
-                return $route;
+                return [self::$routes[$method][$match], $match];
             }
         }
 

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -395,6 +395,38 @@ final class HttpTest extends TestCase
         $this->assertSame('action:abc123,200|shutdown:fileId=abc123,width=200', $result);
     }
 
+    public function testErrorHookSeesPartialMatchArgumentsWhenValidationFails(): void
+    {
+        $route = new Route('GET', '/files/:fileId/things/:thingId');
+        $route
+            ->param('fileId', '', new Text(64), 'file id', false)
+            ->param('thingId', '', new Text(1, min: 0), 'thing id', false)
+            ->action(function ($fileId, $thingId) {
+                echo 'never';
+            });
+
+        $seen = new \stdClass();
+
+        $this->http
+            ->error()
+            ->inject('match')
+            ->action(function (?RouteMatch $match) use ($seen) {
+                $seen->arguments = $match?->arguments;
+            });
+
+        $request = new UtopiaFPMRequestTest();
+        $request::_setParams(['fileId' => 'abc123', 'thingId' => 'too-long-for-the-validator']);
+
+        ob_start();
+        $this->http->execute($route, $request, new Response());
+        ob_end_clean();
+
+        // fileId resolved fine; thingId failed validation.
+        // Error hook should see fileId (and the candidate thingId value).
+        $this->assertSame('abc123', $seen->arguments['fileId'] ?? null);
+        $this->assertSame('too-long-for-the-validator', $seen->arguments['thingId'] ?? null);
+    }
+
     public function testMatchIsNullDuringEarlyErrorBeforeRouting(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'GET';

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -366,6 +366,35 @@ final class HttpTest extends TestCase
         $this->assertSame('(init)-y-def-x-def-(shutdown)', $result);
     }
 
+    public function testShutdownHookCanInjectResolvedArguments(): void
+    {
+        $route = new Route('GET', '/files/:fileId');
+        $route
+            ->param('fileId', '', new Text(64), 'file id', false)
+            ->param('width', 0, new Text(8), 'width', true)
+            ->action(function ($fileId, $width) {
+                echo 'action:' . $fileId . ',' . $width;
+            });
+
+        $this->http
+            ->shutdown()
+            ->inject('arguments')
+            ->action(function (array $arguments) {
+                echo '|shutdown:fileId=' . $arguments['fileId'] . ',width=' . $arguments['width'];
+            });
+
+        $request = new UtopiaFPMRequestTest();
+        $request::_setParams(['fileId' => 'abc123', 'width' => '200']);
+        $_SERVER['REQUEST_URI'] = '/files/abc123';
+
+        ob_start();
+        $this->http->execute($route, $request, new Response());
+        $result = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertSame('action:abc123,200|shutdown:fileId=abc123,width=200', $result);
+    }
+
     /**
      * @return \Iterator<string, array<int, string>>
      */

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -378,9 +378,9 @@ final class HttpTest extends TestCase
 
         $this->http
             ->shutdown()
-            ->inject('arguments')
-            ->action(function (array $arguments) {
-                echo '|shutdown:fileId=' . $arguments['fileId'] . ',width=' . $arguments['width'];
+            ->inject('match')
+            ->action(function (RouteMatch $match) {
+                echo '|shutdown:fileId=' . $match->arguments['fileId'] . ',width=' . $match->arguments['width'];
             });
 
         $request = new UtopiaFPMRequestTest();
@@ -442,7 +442,7 @@ final class HttpTest extends TestCase
         $_SERVER['REQUEST_URI'] = $url;
 
         $this->assertSame($expected, $this->http->match(new Request()));
-        $this->assertSame($expected, $this->http->getResource('route'));
+        $this->assertSame($expected, $this->http->getResource('match')?->route);
     }
 
     public function testNoMismatchRoute(): void
@@ -471,7 +471,7 @@ final class HttpTest extends TestCase
             $route = $this->http->match(new Request(), fresh: true);
 
             $this->assertNull($route);
-            $this->assertNull($this->http->getResource('route'));
+            $this->assertNull($this->http->getResource('match')?->route);
         }
     }
 
@@ -486,7 +486,7 @@ final class HttpTest extends TestCase
             $_SERVER['REQUEST_URI'] = '/path1';
             $matched = $this->http->match(new Request());
             $this->assertSame($route1, $matched);
-            $this->assertSame($route1, $this->http->getResource('route'));
+            $this->assertSame($route1, $this->http->getResource('match')?->route);
 
             // Second request match returns cached route
             $_SERVER['REQUEST_METHOD'] = 'HEAD';
@@ -494,12 +494,12 @@ final class HttpTest extends TestCase
             $request2 = new Request();
             $matched = $this->http->match($request2, fresh: false);
             $this->assertSame($route1, $matched);
-            $this->assertSame($route1, $this->http->getResource('route'));
+            $this->assertSame($route1, $this->http->getResource('match')?->route);
 
             // Fresh match returns new route
             $matched = $this->http->match($request2, fresh: true);
             $this->assertSame($route2, $matched);
-            $this->assertSame($route2, $this->http->getResource('route'));
+            $this->assertSame($route2, $this->http->getResource('match')?->route);
         } catch (\Exception $e) {
             $this->fail($e->getMessage());
         }
@@ -513,7 +513,7 @@ final class HttpTest extends TestCase
         $_SERVER['REQUEST_URI'] = 'https://example.com?x=1';
 
         $this->assertSame($route, $this->http->match(new Request()));
-        $this->assertSame($route, $this->http->getResource('route'));
+        $this->assertSame($route, $this->http->getResource('match')?->route);
     }
 
     public function testCanRunRequest(): void
@@ -552,9 +552,9 @@ final class HttpTest extends TestCase
         $_SERVER['REQUEST_URI'] = '/unknown_path';
 
         Http::init()
-            ->inject('route')
-            ->action(function ($route) {
-                $this->container->set('myRoute', fn() => $route);
+            ->inject('match')
+            ->action(function (RouteMatch $match) {
+                $this->container->set('myRoute', fn() => $match->route);
             });
 
 

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -366,15 +366,6 @@ final class HttpTest extends TestCase
         $this->assertSame('(init)-y-def-x-def-(shutdown)', $result);
     }
 
-    public function testCanSetRoute(): void
-    {
-        $route = new Route('GET', '/path');
-
-        $this->assertNull($this->http->getRoute());
-        $this->http->setRoute($route);
-        $this->assertSame($route, $this->http->getRoute());
-    }
-
     /**
      * @return \Iterator<string, array<int, string>>
      */

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -413,7 +413,7 @@ final class HttpTest extends TestCase
         $_SERVER['REQUEST_URI'] = $url;
 
         $this->assertSame($expected, $this->http->match(new Request()));
-        $this->assertSame($expected, $this->http->getResource("route"));
+        $this->assertSame($expected, $this->http->getResource('route'));
     }
 
     public function testNoMismatchRoute(): void
@@ -442,7 +442,7 @@ final class HttpTest extends TestCase
             $route = $this->http->match(new Request(), fresh: true);
 
             $this->assertNull($route);
-            $this->assertNull($this->http->getResource("route"));
+            $this->assertNull($this->http->getResource('route'));
         }
     }
 
@@ -457,7 +457,7 @@ final class HttpTest extends TestCase
             $_SERVER['REQUEST_URI'] = '/path1';
             $matched = $this->http->match(new Request());
             $this->assertSame($route1, $matched);
-            $this->assertSame($route1, $this->http->getResource("route"));
+            $this->assertSame($route1, $this->http->getResource('route'));
 
             // Second request match returns cached route
             $_SERVER['REQUEST_METHOD'] = 'HEAD';
@@ -465,12 +465,12 @@ final class HttpTest extends TestCase
             $request2 = new Request();
             $matched = $this->http->match($request2, fresh: false);
             $this->assertSame($route1, $matched);
-            $this->assertSame($route1, $this->http->getResource("route"));
+            $this->assertSame($route1, $this->http->getResource('route'));
 
             // Fresh match returns new route
             $matched = $this->http->match($request2, fresh: true);
             $this->assertSame($route2, $matched);
-            $this->assertSame($route2, $this->http->getResource("route"));
+            $this->assertSame($route2, $this->http->getResource('route'));
         } catch (\Exception $e) {
             $this->fail($e->getMessage());
         }
@@ -484,7 +484,7 @@ final class HttpTest extends TestCase
         $_SERVER['REQUEST_URI'] = 'https://example.com?x=1';
 
         $this->assertSame($route, $this->http->match(new Request()));
-        $this->assertSame($route, $this->http->getResource("route"));
+        $this->assertSame($route, $this->http->getResource('route'));
     }
 
     public function testCanRunRequest(): void

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -395,37 +395,6 @@ final class HttpTest extends TestCase
         $this->assertSame('action:abc123,200|shutdown:fileId=abc123,width=200', $result);
     }
 
-    public function testInitHookSeesPathValuesInMatchArguments(): void
-    {
-        $_SERVER['REQUEST_METHOD'] = 'GET';
-        $_SERVER['REQUEST_URI'] = '/databases/db_1/collections/col_2';
-
-        Http::get('/databases/:databaseId/collections/:collectionId')
-            ->param('databaseId', '', new Text(64), 'database id', false)
-            ->param('collectionId', '', new Text(64), 'collection id', false)
-            ->inject('response')
-            ->action(function ($databaseId, $collectionId, $response) {
-                $response->send('action:' . $databaseId . '/' . $collectionId);
-            });
-
-        $seen = new \stdClass();
-
-        Http::init()
-            ->inject('match')
-            ->action(function (?RouteMatch $match) use ($seen) {
-                $seen->arguments = $match?->arguments;
-            });
-
-        ob_start();
-        $this->http->run(new Request(), new Response());
-        $result = ob_get_contents();
-        ob_end_clean();
-
-        $this->assertSame('action:db_1/col_2', $result);
-        $this->assertSame('db_1', $seen->arguments['databaseId'] ?? null);
-        $this->assertSame('col_2', $seen->arguments['collectionId'] ?? null);
-    }
-
     public function testMatchIsNullDuringEarlyErrorBeforeRouting(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'GET';

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -413,7 +413,7 @@ final class HttpTest extends TestCase
         $_SERVER['REQUEST_URI'] = $url;
 
         $this->assertSame($expected, $this->http->match(new Request()));
-        $this->assertSame($expected, $this->http->getRoute());
+        $this->assertSame($expected, $this->http->getResource("route"));
     }
 
     public function testNoMismatchRoute(): void
@@ -442,7 +442,7 @@ final class HttpTest extends TestCase
             $route = $this->http->match(new Request(), fresh: true);
 
             $this->assertNull($route);
-            $this->assertNull($this->http->getRoute());
+            $this->assertNull($this->http->getResource("route"));
         }
     }
 
@@ -457,7 +457,7 @@ final class HttpTest extends TestCase
             $_SERVER['REQUEST_URI'] = '/path1';
             $matched = $this->http->match(new Request());
             $this->assertSame($route1, $matched);
-            $this->assertSame($route1, $this->http->getRoute());
+            $this->assertSame($route1, $this->http->getResource("route"));
 
             // Second request match returns cached route
             $_SERVER['REQUEST_METHOD'] = 'HEAD';
@@ -465,12 +465,12 @@ final class HttpTest extends TestCase
             $request2 = new Request();
             $matched = $this->http->match($request2, fresh: false);
             $this->assertSame($route1, $matched);
-            $this->assertSame($route1, $this->http->getRoute());
+            $this->assertSame($route1, $this->http->getResource("route"));
 
             // Fresh match returns new route
             $matched = $this->http->match($request2, fresh: true);
             $this->assertSame($route2, $matched);
-            $this->assertSame($route2, $this->http->getRoute());
+            $this->assertSame($route2, $this->http->getResource("route"));
         } catch (\Exception $e) {
             $this->fail($e->getMessage());
         }
@@ -484,7 +484,7 @@ final class HttpTest extends TestCase
         $_SERVER['REQUEST_URI'] = 'https://example.com?x=1';
 
         $this->assertSame($route, $this->http->match(new Request()));
-        $this->assertSame($route, $this->http->getRoute());
+        $this->assertSame($route, $this->http->getResource("route"));
     }
 
     public function testCanRunRequest(): void
@@ -523,8 +523,8 @@ final class HttpTest extends TestCase
         $_SERVER['REQUEST_URI'] = '/unknown_path';
 
         Http::init()
-            ->action(function () {
-                $route = $this->http->getRoute();
+            ->inject('route')
+            ->action(function ($route) {
                 $this->container->set('myRoute', fn() => $route);
             });
 

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -395,6 +395,35 @@ final class HttpTest extends TestCase
         $this->assertSame('action:abc123,200|shutdown:fileId=abc123,width=200', $result);
     }
 
+    public function testMatchIsNullDuringEarlyErrorBeforeRouting(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/whatever';
+
+        Http::onRequest()
+            ->action(function (): void {
+                throw new \RuntimeException('boom');
+            });
+
+        $seen = new \stdClass();
+        $seen->matchWasSet = false;
+        $seen->matchValue = 'sentinel';
+
+        Http::error()
+            ->inject('match')
+            ->action(function (?RouteMatch $match) use ($seen): void {
+                $seen->matchWasSet = true;
+                $seen->matchValue = $match;
+            });
+
+        ob_start();
+        @$this->http->run(new Request(), new Response());
+        ob_end_clean();
+
+        $this->assertTrue($seen->matchWasSet, 'global error hook should have run');
+        $this->assertNull($seen->matchValue, "'match' should be null on the context before routing");
+    }
+
     /**
      * @return \Iterator<string, array<int, string>>
      */

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -395,6 +395,37 @@ final class HttpTest extends TestCase
         $this->assertSame('action:abc123,200|shutdown:fileId=abc123,width=200', $result);
     }
 
+    public function testInitHookSeesPathValuesInMatchArguments(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/databases/db_1/collections/col_2';
+
+        Http::get('/databases/:databaseId/collections/:collectionId')
+            ->param('databaseId', '', new Text(64), 'database id', false)
+            ->param('collectionId', '', new Text(64), 'collection id', false)
+            ->inject('response')
+            ->action(function ($databaseId, $collectionId, $response) {
+                $response->send('action:' . $databaseId . '/' . $collectionId);
+            });
+
+        $seen = new \stdClass();
+
+        Http::init()
+            ->inject('match')
+            ->action(function (?RouteMatch $match) use ($seen) {
+                $seen->arguments = $match?->arguments;
+            });
+
+        ob_start();
+        $this->http->run(new Request(), new Response());
+        $result = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertSame('action:db_1/col_2', $result);
+        $this->assertSame('db_1', $seen->arguments['databaseId'] ?? null);
+        $this->assertSame('col_2', $seen->arguments['collectionId'] ?? null);
+    }
+
     public function testMatchIsNullDuringEarlyErrorBeforeRouting(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'GET';

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -23,9 +23,9 @@ final class RouterTest extends TestCase
         Router::addRoute($routeAbout);
         Router::addRoute($routeAboutMe);
 
-        $this->assertSame($routeIndex, Router::match(Http::REQUEST_METHOD_GET, '/')[0] ?? null);
-        $this->assertSame($routeAbout, Router::match(Http::REQUEST_METHOD_GET, '/about')[0] ?? null);
-        $this->assertSame($routeAboutMe, Router::match(Http::REQUEST_METHOD_GET, '/about/me')[0] ?? null);
+        $this->assertSame($routeIndex, Router::match(Http::REQUEST_METHOD_GET, '/')->route);
+        $this->assertSame($routeAbout, Router::match(Http::REQUEST_METHOD_GET, '/about')->route);
+        $this->assertSame($routeAboutMe, Router::match(Http::REQUEST_METHOD_GET, '/about/me')->route);
     }
 
     public function testCanMatchUrlWithPlaceholder(): void
@@ -44,12 +44,12 @@ final class RouterTest extends TestCase
         Router::addRoute($routeBlogPostComments);
         Router::addRoute($routeBlogPostCommentsSingle);
 
-        $this->assertSame($routeBlog, Router::match(Http::REQUEST_METHOD_GET, '/blog')[0] ?? null);
-        $this->assertSame($routeBlogAuthors, Router::match(Http::REQUEST_METHOD_GET, '/blog/authors')[0] ?? null);
-        $this->assertSame($routeBlogAuthorsComments, Router::match(Http::REQUEST_METHOD_GET, '/blog/authors/comments')[0] ?? null);
-        $this->assertSame($routeBlogPost, Router::match(Http::REQUEST_METHOD_GET, '/blog/test')[0] ?? null);
-        $this->assertSame($routeBlogPostComments, Router::match(Http::REQUEST_METHOD_GET, '/blog/test/comments')[0] ?? null);
-        $this->assertSame($routeBlogPostCommentsSingle, Router::match(Http::REQUEST_METHOD_GET, '/blog/test/comments/:comment')[0] ?? null);
+        $this->assertSame($routeBlog, Router::match(Http::REQUEST_METHOD_GET, '/blog')->route);
+        $this->assertSame($routeBlogAuthors, Router::match(Http::REQUEST_METHOD_GET, '/blog/authors')->route);
+        $this->assertSame($routeBlogAuthorsComments, Router::match(Http::REQUEST_METHOD_GET, '/blog/authors/comments')->route);
+        $this->assertSame($routeBlogPost, Router::match(Http::REQUEST_METHOD_GET, '/blog/test')->route);
+        $this->assertSame($routeBlogPostComments, Router::match(Http::REQUEST_METHOD_GET, '/blog/test/comments')->route);
+        $this->assertSame($routeBlogPostCommentsSingle, Router::match(Http::REQUEST_METHOD_GET, '/blog/test/comments/:comment')->route);
     }
 
     public function testCanMatchUrlWithWildcard(): void
@@ -62,11 +62,11 @@ final class RouterTest extends TestCase
         Router::addRoute($routeAbout);
         Router::addRoute($routeAboutWildcard);
 
-        $this->assertSame($routeIndex, Router::match('GET', '/')[0] ?? null);
-        $this->assertSame($routeAbout, Router::match('GET', '/about')[0] ?? null);
-        $this->assertSame($routeAboutWildcard, Router::match('GET', '/about/me')[0] ?? null);
-        $this->assertSame($routeAboutWildcard, Router::match('GET', '/about/you')[0] ?? null);
-        $this->assertSame($routeAboutWildcard, Router::match('GET', '/about/me/myself/i')[0] ?? null);
+        $this->assertSame($routeIndex, Router::match('GET', '/')->route);
+        $this->assertSame($routeAbout, Router::match('GET', '/about')->route);
+        $this->assertSame($routeAboutWildcard, Router::match('GET', '/about/me')->route);
+        $this->assertSame($routeAboutWildcard, Router::match('GET', '/about/you')->route);
+        $this->assertSame($routeAboutWildcard, Router::match('GET', '/about/me/myself/i')->route);
     }
 
     public function testCanMatchHttpMethod(): void
@@ -77,11 +77,11 @@ final class RouterTest extends TestCase
         Router::addRoute($routeGET);
         Router::addRoute($routePOST);
 
-        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/')[0] ?? null);
-        $this->assertSame($routePOST, Router::match(Http::REQUEST_METHOD_POST, '/')[0] ?? null);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/')->route);
+        $this->assertSame($routePOST, Router::match(Http::REQUEST_METHOD_POST, '/')->route);
 
-        $this->assertNotSame($routeGET, Router::match(Http::REQUEST_METHOD_POST, '/')[0]);
-        $this->assertNotSame($routePOST, Router::match(Http::REQUEST_METHOD_GET, '/')[0]);
+        $this->assertNotSame($routeGET, Router::match(Http::REQUEST_METHOD_POST, '/')?->route);
+        $this->assertNotSame($routePOST, Router::match(Http::REQUEST_METHOD_GET, '/')?->route);
     }
 
     public function testCanMatchAlias(): void
@@ -93,9 +93,9 @@ final class RouterTest extends TestCase
 
         Router::addRoute($routeGET);
 
-        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/target')[0] ?? null);
-        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias')[0] ?? null);
-        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias2')[0] ?? null);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/target')->route);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias')->route);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias2')->route);
     }
 
     public function testCanMatchMultipleAliases(): void
@@ -108,10 +108,10 @@ final class RouterTest extends TestCase
 
         Router::addRoute($routeGET);
 
-        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/target')[0] ?? null);
-        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias1')[0] ?? null);
-        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias2')[0] ?? null);
-        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias3')[0] ?? null);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/target')->route);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias1')->route);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias2')->route);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias3')->route);
     }
 
     public function testCanMatchMix(): void
@@ -127,14 +127,14 @@ final class RouterTest extends TestCase
 
         Router::addRoute($routeGET);
 
-        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/')[0] ?? null);
-        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/console')[0] ?? null);
-        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/invite')[0] ?? null);
-        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/login')[0] ?? null);
-        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/recover')[0] ?? null);
-        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/console/lorem/ipsum/dolor')[0] ?? null);
-        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/auth/lorem/ipsum')[0] ?? null);
-        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/register/lorem/ipsum')[0] ?? null);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/')->route);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/console')->route);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/invite')->route);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/login')->route);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/recover')->route);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/console/lorem/ipsum/dolor')->route);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/auth/lorem/ipsum')->route);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/register/lorem/ipsum')->route);
     }
 
     public function testCanMatchFilename(): void
@@ -142,7 +142,7 @@ final class RouterTest extends TestCase
         $routeGET = new Route(Http::REQUEST_METHOD_GET, '/robots.txt');
 
         Router::addRoute($routeGET);
-        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/robots.txt')[0] ?? null);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/robots.txt')->route);
     }
 
     public function testCannotFindUnknownRouteByPath(): void
@@ -156,7 +156,7 @@ final class RouterTest extends TestCase
 
         Router::addRoute($route);
 
-        $this->assertSame($route, Router::match(Http::REQUEST_METHOD_GET, '/404')[0] ?? null);
+        $this->assertSame($route, Router::match(Http::REQUEST_METHOD_GET, '/404')->route);
 
         $this->assertNull(Router::match(Http::REQUEST_METHOD_POST, '/404'));
     }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -23,9 +23,9 @@ final class RouterTest extends TestCase
         Router::addRoute($routeAbout);
         Router::addRoute($routeAboutMe);
 
-        $this->assertEquals($routeIndex, Router::match(Http::REQUEST_METHOD_GET, '/'));
-        $this->assertEquals($routeAbout, Router::match(Http::REQUEST_METHOD_GET, '/about'));
-        $this->assertEquals($routeAboutMe, Router::match(Http::REQUEST_METHOD_GET, '/about/me'));
+        $this->assertSame($routeIndex, Router::match(Http::REQUEST_METHOD_GET, '/')[0] ?? null);
+        $this->assertSame($routeAbout, Router::match(Http::REQUEST_METHOD_GET, '/about')[0] ?? null);
+        $this->assertSame($routeAboutMe, Router::match(Http::REQUEST_METHOD_GET, '/about/me')[0] ?? null);
     }
 
     public function testCanMatchUrlWithPlaceholder(): void
@@ -44,12 +44,12 @@ final class RouterTest extends TestCase
         Router::addRoute($routeBlogPostComments);
         Router::addRoute($routeBlogPostCommentsSingle);
 
-        $this->assertEquals($routeBlog, Router::match(Http::REQUEST_METHOD_GET, '/blog'));
-        $this->assertEquals($routeBlogAuthors, Router::match(Http::REQUEST_METHOD_GET, '/blog/authors'));
-        $this->assertEquals($routeBlogAuthorsComments, Router::match(Http::REQUEST_METHOD_GET, '/blog/authors/comments'));
-        $this->assertEquals($routeBlogPost, Router::match(Http::REQUEST_METHOD_GET, '/blog/test'));
-        $this->assertEquals($routeBlogPostComments, Router::match(Http::REQUEST_METHOD_GET, '/blog/test/comments'));
-        $this->assertEquals($routeBlogPostCommentsSingle, Router::match(Http::REQUEST_METHOD_GET, '/blog/test/comments/:comment'));
+        $this->assertSame($routeBlog, Router::match(Http::REQUEST_METHOD_GET, '/blog')[0] ?? null);
+        $this->assertSame($routeBlogAuthors, Router::match(Http::REQUEST_METHOD_GET, '/blog/authors')[0] ?? null);
+        $this->assertSame($routeBlogAuthorsComments, Router::match(Http::REQUEST_METHOD_GET, '/blog/authors/comments')[0] ?? null);
+        $this->assertSame($routeBlogPost, Router::match(Http::REQUEST_METHOD_GET, '/blog/test')[0] ?? null);
+        $this->assertSame($routeBlogPostComments, Router::match(Http::REQUEST_METHOD_GET, '/blog/test/comments')[0] ?? null);
+        $this->assertSame($routeBlogPostCommentsSingle, Router::match(Http::REQUEST_METHOD_GET, '/blog/test/comments/:comment')[0] ?? null);
     }
 
     public function testCanMatchUrlWithWildcard(): void
@@ -62,11 +62,11 @@ final class RouterTest extends TestCase
         Router::addRoute($routeAbout);
         Router::addRoute($routeAboutWildcard);
 
-        $this->assertEquals($routeIndex, Router::match('GET', '/'));
-        $this->assertEquals($routeAbout, Router::match('GET', '/about'));
-        $this->assertEquals($routeAboutWildcard, Router::match('GET', '/about/me'));
-        $this->assertEquals($routeAboutWildcard, Router::match('GET', '/about/you'));
-        $this->assertEquals($routeAboutWildcard, Router::match('GET', '/about/me/myself/i'));
+        $this->assertSame($routeIndex, Router::match('GET', '/')[0] ?? null);
+        $this->assertSame($routeAbout, Router::match('GET', '/about')[0] ?? null);
+        $this->assertSame($routeAboutWildcard, Router::match('GET', '/about/me')[0] ?? null);
+        $this->assertSame($routeAboutWildcard, Router::match('GET', '/about/you')[0] ?? null);
+        $this->assertSame($routeAboutWildcard, Router::match('GET', '/about/me/myself/i')[0] ?? null);
     }
 
     public function testCanMatchHttpMethod(): void
@@ -77,11 +77,11 @@ final class RouterTest extends TestCase
         Router::addRoute($routeGET);
         Router::addRoute($routePOST);
 
-        $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/'));
-        $this->assertEquals($routePOST, Router::match(Http::REQUEST_METHOD_POST, '/'));
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/')[0] ?? null);
+        $this->assertSame($routePOST, Router::match(Http::REQUEST_METHOD_POST, '/')[0] ?? null);
 
-        $this->assertNotEquals($routeGET, Router::match(Http::REQUEST_METHOD_POST, '/'));
-        $this->assertNotEquals($routePOST, Router::match(Http::REQUEST_METHOD_GET, '/'));
+        $this->assertNotSame($routeGET, Router::match(Http::REQUEST_METHOD_POST, '/')[0]);
+        $this->assertNotSame($routePOST, Router::match(Http::REQUEST_METHOD_GET, '/')[0]);
     }
 
     public function testCanMatchAlias(): void
@@ -93,9 +93,9 @@ final class RouterTest extends TestCase
 
         Router::addRoute($routeGET);
 
-        $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/target'));
-        $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias'));
-        $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias2'));
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/target')[0] ?? null);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias')[0] ?? null);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias2')[0] ?? null);
     }
 
     public function testCanMatchMultipleAliases(): void
@@ -108,10 +108,10 @@ final class RouterTest extends TestCase
 
         Router::addRoute($routeGET);
 
-        $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/target'));
-        $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias1'));
-        $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias2'));
-        $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias3'));
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/target')[0] ?? null);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias1')[0] ?? null);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias2')[0] ?? null);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/alias3')[0] ?? null);
     }
 
     public function testCanMatchMix(): void
@@ -127,14 +127,14 @@ final class RouterTest extends TestCase
 
         Router::addRoute($routeGET);
 
-        $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/'));
-        $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/console'));
-        $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/invite'));
-        $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/login'));
-        $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/recover'));
-        $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/console/lorem/ipsum/dolor'));
-        $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/auth/lorem/ipsum'));
-        $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/register/lorem/ipsum'));
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/')[0] ?? null);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/console')[0] ?? null);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/invite')[0] ?? null);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/login')[0] ?? null);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/recover')[0] ?? null);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/console/lorem/ipsum/dolor')[0] ?? null);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/auth/lorem/ipsum')[0] ?? null);
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/register/lorem/ipsum')[0] ?? null);
     }
 
     public function testCanMatchFilename(): void
@@ -142,7 +142,7 @@ final class RouterTest extends TestCase
         $routeGET = new Route(Http::REQUEST_METHOD_GET, '/robots.txt');
 
         Router::addRoute($routeGET);
-        $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/robots.txt'));
+        $this->assertSame($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/robots.txt')[0] ?? null);
     }
 
     public function testCannotFindUnknownRouteByPath(): void
@@ -156,7 +156,7 @@ final class RouterTest extends TestCase
 
         Router::addRoute($route);
 
-        $this->assertEquals($route, Router::match(Http::REQUEST_METHOD_GET, '/404'));
+        $this->assertSame($route, Router::match(Http::REQUEST_METHOD_GET, '/404')[0] ?? null);
 
         $this->assertNull(Router::match(Http::REQUEST_METHOD_POST, '/404'));
     }


### PR DESCRIPTION
## Summary

Under the Swoole and SwooleCoroutine adapters, multiple requests run concurrently in the same PHP process and share a single `Http` instance plus the static `Router` / `Route` / `Hook` registries. Today, per-request data is written onto those shared objects — when a coroutine yields on I/O, another coroutine clobbers it. This PR removes four such mutations and replaces the one valid use case with a race-free equivalent.

### Races fixed

1. **`Http::$route`** — instance property holding "the current route." Two coroutines on the same `Http` overwrote each other; `getRoute()` and the telemetry attribution in `run()` saw the wrong route after any yield. Moved into the per-request context container (coroutine-local via `Coroutine::getContext()` in both Swoole adapters).
2. **`Route::$matchedPath`** — `Router::match()` mutated the *singleton* `Route` stored in `Router::$routes` via `setMatchedPath()`. Concurrent hits on the same route through different aliases / wildcard segments raced, breaking path-param extraction in `execute()`. `Router::match()` now returns the matched route alongside the prepared-path string in an immutable value class; the singleton is no longer mutated.
3. **`Http::$wildcardRoute`** — the wildcard branch did `$route->path($path)` on the singleton, so two concurrent wildcard requests fought over `$path`. Now we `clone` the wildcard route per request before stamping the URI.
4. **`Hook::setParamValue()` writeback in `Http::getArguments()`** — every resolved param value was written back onto the shared `Hook`/`Route`. Removed. Replaced with the per-request `RouteMatch::$arguments` map (see below).

## The `RouteMatch` value class

Routing state — the matched `Route`, the prepared-path string it was matched under, and the name-keyed argument map — is one logical thing, so this PR bundles it into a single value class:

```php
final class RouteMatch
{
    public function __construct(
        public readonly Route $route,
        public readonly string $path,
        public array $arguments = [],
    ) {}
}
```

`$route` and `$path` are immutable. `$arguments` is mutable so the framework can fill it in once the action's params resolve, without rebuilding the `RouteMatch`. Safe because the RouteMatch lives on the per-request context container (coroutine-local under Swoole), so only the request's own coroutine touches it.

Lifecycle:

- `Router::match()` returns `?RouteMatch` (with empty `$arguments`).
- `Http::match()` stores it on the per-request context container under `'match'` (or `null` if no match).
- Right before the route action runs, `Http::execute()` writes `$arguments` with the full resolved+validated argument map (path + query + body, post-validator) — same `RouteMatch` instance, no replacement on the context.
- The wildcard branch builds a `RouteMatch` around the cloned wildcard route.
- Telemetry attribution in `run()` reads it once at the end.

> Note: `$match->arguments` is empty during `init` hooks — they run before the route's params are resolved. Surfacing path values into `$arguments` earlier (so init hooks can read URI segments like `{databaseId}` directly) is being tracked as a follow-up PR.

## Terminology: resources vs. context

This PR formalizes a split that was already implicit in the codebase:

- **`Http::setResource()` / `Http::getResource()`** — singletons on the global container. Same as before.
- **`Http::setContext()`** (now public) — per-request values on the adapter's request container, which is coroutine-local under the Swoole adapters. Replaces the old `setRequestResource()` (`protected`, internal-only).

On the adapter, there is exactly one public reader:

- **`Adapter::getContext(): Container`** — returns the container for the current execution context. Inside a request, that's the per-request container (coroutine-local under Swoole), with parent-chain fallback to the global one for singleton lookups. Outside a request (boot, `onStart` hooks), it's the global container directly.

The global container is constructor-injected into the adapter and not retrievable post-construction. There is no public `getContainer()` — callers don't need to know which scope they're in; `getContext()` returns the right one for where they are.

The framework writes the following keys on the context container:

| Key | When set | What it holds |
|---|---|---|
| `request` / `response` | Top of `runInternal()` | `Request` / `Response` |
| `error` | When an exception is caught (`init`/`shutdown`/`runInternal`/`onStart`) | `\Throwable` |
| `match` | Seeded to `null` at the top of `runInternal()`. Set to a `RouteMatch` once `match()` resolves; `$arguments` is filled with the resolved+validated set right before the action runs. The same `RouteMatch` instance is reused throughout the request. | `RouteMatch`, or `null` (no route matched, or read before routing) |

Inject `match` into any hook/action:

```php
Http::shutdown()
    ->inject('match')
    ->action(function (RouteMatch $match) {
        // post-validation values, race-free under Swoole
        $template = $match->arguments['template'] ?? '';
    });
```

## Breaking changes

This PR ships **eight breaking changes**. All are public-facing but localized.

### 1. `Router::match()` return type

**Before:** `public static function match(string $method, string $path): ?Route`
**After:**  `public static function match(string $method, string $path): ?RouteMatch`

```php
// Before
$route = Router::match('GET', '/users/123');
if ($route !== null) { /* ... */ }

// After
$match = Router::match('GET', '/users/123');
if ($match !== null) {
    $route = $match->route;
    $matchedPath = $match->path;
}
```

### 2. `Http::getRoute()` / `Http::setRoute()` removed

Both methods are gone. The current route is part of the `RouteMatch` value class on the context now.

- **Read:** `$http->getResource('match')?->route` or inject `'match'`.
- **Write:** the framework sets the `RouteMatch` during `match()` / `runInternal()`; application code shouldn't.

### 3. `Hook` param values no longer populated by request handling

`Http::getArguments()` no longer calls `$hook->setParamValue($key, $value)`. If you called `$hook->getParamValue($key)` or `$hook->getParamsValues()` from inside a route action / `init` / `shutdown` / `error` hook expecting it to return the resolved value for the current request, it will now return `null`.

**Replacement:** inject `'match'` and read `$match->arguments['key']`. The framework populates this with the resolved+validated argument map right before the action runs, so shutdown / error hooks see the same values the action received. Race-free because the `RouteMatch` lives on the per-request context container (coroutine-local under Swoole), so only the request's own coroutine touches it.

```php
// Before
$value = $hook->getParamValue('fileId');

// After (from a shutdown / error hook)
Http::shutdown()
    ->inject('match')
    ->action(function (RouteMatch $match) {
        $value = $match->arguments['fileId'] ?? null;
    });
```

`init` hooks see `$match->arguments` as empty — they run before the route's params are resolved. The full validated map is available from the action onward (and to all subsequent shutdown / error hooks). A follow-up PR will surface path values earlier so init hooks can read URI segments without falling back to `Route::getPathValues()`.

### 4. `Route::setMatchedPath()` / `Route::getMatchedPath()` removed

These methods (and the underlying `Route::$matchedPath` property) have been deleted outright. Read it via `$match->path`.

### 5. `Http::$requestContainer` property removed

The `protected ?Container $requestContainer = null;` field was never assigned by the framework. Removed. If a subclass references it, drop the reference — per-request state lives on the adapter's context (`$server->getContext()`), which is coroutine-local in the Swoole adapters.

### 6. `setRequestResource()` renamed to `setContext()` (and now public)

`Http::setRequestResource()` (protected) is now `Http::setContext()` and is **public** — application code can use it to register per-request values, just as it already could with `setResource()` for singletons. Subclasses that overrode `setRequestResource()` need to rename their override (and widen visibility if they kept it protected). The Swoole adapters' coroutine-key constant `REQUEST_CONTAINER_CONTEXT_KEY` is likewise now `CONTEXT_KEY`, and the underlying string moved from `'__utopia_http_request_container'` to `'__utopia_http_context'`. If a subclass of either adapter referenced these, rename to match.

### 7. `Adapter::getContainer()` removed; replaced by `getContext()`

`Adapter::getContainer()` is gone. The adapter now exposes only **`getContext(): Container`** — a single public reader that returns the container for the current execution context (per-request inside a request with parent-fallback to global, global directly outside one). The global container stays constructor-injected and is not retrievable post-construction.

Custom `Adapter` subclasses must implement `getContext()` and drop their `getContainer()` implementation. Application code calling `$server->getContainer()` should switch to `$server->getContext()`; semantics match `getContainer()`'s old behavior (smart-routed by execution context), so a one-line rename is the whole migration.

### 8. Wildcard `Route` is now a per-request clone

The wildcard route inside `RouteMatch` for a wildcard handler is a per-request **clone** of `Http::$wildcardRoute`, not the singleton. Identity comparisons (`$match->route === Http::$wildcardRoute`) will fail. Property reads (`getPath()`, `getAction()`, etc.) behave identically.

## Migration guide

For typical application code (defining routes, hooks, handlers), **no changes are required** unless you read the current route or used `$hook->getParamValue()`. The breaks only matter if you call the framework's routing primitives directly or subclass `Http` / the adapters.

| If you do this… | Change to… |
|---|---|
| `$route = Router::match($m, $p);` | `$match = Router::match($m, $p); $route = $match?->route;` |
| `$http->getRoute()` from app code | `$http->getResource('match')?->route` or `->inject('match')` and read `$match->route` |
| `$http->setRoute($route)` from app code | drop the call — set automatically during `match()` / `runInternal()` |
| `$route->getMatchedPath()` | `$match->path` |
| `$route->setMatchedPath(...)` | no replacement — Routes are no longer mutated per-request |
| `$server->getContainer()` (anywhere) | `$server->getContext()` — same smart-routed behavior, just the new name |
| `class MyAdapter extends Adapter { public function getContainer() {...} }` | implement `getContext(): Container` instead; drop the `getContainer()` override |
| `class MyHttp extends Http { /* reads $this->requestContainer */ }` | use `$this->server->getContext()` |
| `class MyHttp extends Http { protected function setRequestResource(...) }` | rename override to `setContext(...)` |
| Adapter subclass referencing `REQUEST_CONTAINER_CONTEXT_KEY` | rename to `CONTEXT_KEY` |
| `$hook->getParamValue('foo')` inside a shutdown/error handler | `->inject('match')` and read `$match->arguments['foo']` |
| `$route === Http::$wildcardRoute` inside a wildcard handler | compare on a stable property (e.g. `$route->getMethod()`), or check `Http::$wildcardRoute !== null && $route->getAction() === Http::$wildcardRoute->getAction()` |

If you run on FPM only, everything keeps working identically — there is no concurrency in FPM, so the races never fire and the new code paths are equivalent to the old ones.

## Test plan

- [x] `vendor/bin/phpunit tests/HttpTest.php tests/RouterTest.php tests/RouteTest.php tests/RequestTest.php` — 72/72 pass (added `testShutdownHookCanInjectResolvedArguments` covering the `RouteMatch::$arguments` flow).
- [x] `vendor/bin/phpstan analyse` — clean at level 7.
- [x] `composer format:check` — clean (Pint).
- [ ] e2e suite (`ResponseFPMTest`, `ResponseSwooleTest`) requires the `swoole` / `fpm` Docker hosts from `docker-compose.yml`; unchanged from `main` locally — verify in CI.
- [ ] Manual: hit a Swoole-backed deploy with concurrent requests against (a) the same parameterized route via different aliases, (b) the wildcard route from two clients in parallel, (c) a route whose handler awaits I/O and then reads `getResource('match')`, (d) a shutdown hook that injects `'match'` and substitutes labels like `{request.fileId}` from `$match->arguments`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






