### PR TITLE
Refactor: split static resources from per-request context

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ use Utopia\Http\Request;
 use Utopia\Http\Response;
 use Utopia\Http\Adapter\FPM\Server;
 
-$container = new Container();
+$resources = new Container();
 
 Http::get('/hello-world') // Define Route
     ->inject('request')
@@ -46,7 +46,7 @@ Http::get('/hello-world') // Define Route
 
 Http::setMode(Http::MODE_TYPE_PRODUCTION);
 
-$http = new Http(new Server(), 'America/New_York', $container);
+$http = new Http(new Server($resources), 'America/New_York');
 $http->start();
 ```
 
@@ -74,7 +74,7 @@ use Utopia\Http\Http;
 use Utopia\Http\Response;
 use Utopia\Http\Adapter\FPM\Server;
 
-$container = new Container();
+$resources = new Container();
 
 Http::get('/')
     ->inject('response')
@@ -84,7 +84,7 @@ Http::get('/')
         }
     );
 
-$http = new Http(new Server(), 'America/New_York', $container);
+$http = new Http(new Server($resources), 'America/New_York');
 $http->start();
 ```
 
@@ -99,7 +99,7 @@ use Utopia\Http\Request;
 use Utopia\Http\Response;
 use Utopia\Http\Adapter\Swoole\Server;
 
-$container = new Container();
+$resources = new Container();
 
 Http::get('/')
     ->inject('request')
@@ -110,7 +110,7 @@ Http::get('/')
         }
     );
 
-$http = new Http(new Server('0.0.0.0', '80'), 'America/New_York', $container);
+$http = new Http(new Server('0.0.0.0', '80', resources: $resources), 'America/New_York');
 $http->start();
 ```
 
@@ -217,12 +217,12 @@ Groups are designed to be actions that run during the lifecycle of requests to e
 
 ### Resources
 
-Resources allow you to prepare dependencies for requests such as database connections or shared services. Register application dependencies on the DI container with `set()`. Runtime values such as `request`, `response`, `route`, `error`, and `context` are scoped by `Http` for each request.
+Resources allow you to prepare dependencies for requests such as database connections or shared services. Register application dependencies on the resources container with `set()`. Runtime values such as `request`, `response`, `route`, and `error` are registered on the per-request `context` container by `Http` for each request.
 
-Define a dependency on the DI container:
+Define a dependency on the resources container:
 
 ```php
-$container->set('bootTime', function () {
+$resources->set('bootTime', function () {
     return \microtime(true);
 });
 ```
@@ -230,7 +230,7 @@ $container->set('bootTime', function () {
 Inject resource into endpoint action:
 
 ```php
-$http = new Http(new Server(), 'America/New_York', $container);
+$http = new Http(new Server($resources), 'America/New_York');
 
 Http::get('/')
     ->inject('bootTime')

--- a/src/Http/Adapter.php
+++ b/src/Http/Adapter.php
@@ -11,5 +11,26 @@ abstract class Adapter
     abstract public function onStart(callable $callback): void;
     abstract public function onRequest(callable $callback): void;
     abstract public function start(): void;
-    abstract public function getContainer(): Container;
+
+    /**
+     * Static resources container.
+     *
+     * Long-lived, shared across every request for the lifetime of the server.
+     * Use this for things wired up at boot (config, clients, services) that
+     * should be reused across requests. Available before any request begins,
+     * inside server start hooks, and as the parent of every request context.
+     */
+    abstract public function resources(): Container;
+
+    /**
+     * Per-request context container.
+     *
+     * A fresh child container created for each incoming request and disposed
+     * when the request ends. Use it to register or read request-scoped values
+     * (request, response, route, error, ...). Lookups fall through to
+     * {@see self::resources()}, so static resources remain reachable from
+     * within request handlers. Outside of a request, this returns the static
+     * resources container.
+     */
+    abstract public function context(): Container;
 }

--- a/src/Http/Adapter/FPM/Server.php
+++ b/src/Http/Adapter/FPM/Server.php
@@ -7,6 +7,8 @@ use Utopia\Http\Adapter;
 
 class Server extends Adapter
 {
+    private ?Container $context = null;
+
     public function __construct(private Container $resources) {}
 
     public function onRequest(callable $callback): void
@@ -14,10 +16,15 @@ class Server extends Adapter
         $request = new Request();
         $response = new Response();
 
-        $this->resources->set('fpmRequest', fn() => $request);
-        $this->resources->set('fpmResponse', fn() => $response);
+        $this->context = new Container($this->resources);
+        $this->context->set('fpmRequest', fn() => $request);
+        $this->context->set('fpmResponse', fn() => $response);
 
-        \call_user_func($callback, $request, $response);
+        try {
+            \call_user_func($callback, $request, $response);
+        } finally {
+            $this->context = null;
+        }
     }
 
     public function onStart(callable $callback): void
@@ -32,7 +39,7 @@ class Server extends Adapter
 
     public function context(): Container
     {
-        return $this->resources;
+        return $this->context ?? $this->resources;
     }
 
     public function start(): void {}

--- a/src/Http/Adapter/FPM/Server.php
+++ b/src/Http/Adapter/FPM/Server.php
@@ -7,15 +7,15 @@ use Utopia\Http\Adapter;
 
 class Server extends Adapter
 {
-    public function __construct(private Container $container) {}
+    public function __construct(private Container $resources) {}
 
     public function onRequest(callable $callback): void
     {
         $request = new Request();
         $response = new Response();
 
-        $this->container->set('fpmRequest', fn() => $request);
-        $this->container->set('fpmResponse', fn() => $response);
+        $this->resources->set('fpmRequest', fn() => $request);
+        $this->resources->set('fpmResponse', fn() => $response);
 
         \call_user_func($callback, $request, $response);
     }
@@ -25,9 +25,14 @@ class Server extends Adapter
         \call_user_func($callback, $this);
     }
 
-    public function getContainer(): Container
+    public function resources(): Container
     {
-        return $this->container;
+        return $this->resources;
+    }
+
+    public function context(): Container
+    {
+        return $this->resources;
     }
 
     public function start(): void {}

--- a/src/Http/Adapter/Swoole/Server.php
+++ b/src/Http/Adapter/Swoole/Server.php
@@ -12,39 +12,47 @@ use Utopia\Http\Adapter;
 class Server extends Adapter
 {
     protected SwooleServer $server;
-    protected const string REQUEST_CONTAINER_CONTEXT_KEY = '__utopia_http_request_container';
-    protected Container $container;
+    protected const string CONTEXT_KEY = '__utopia__';
 
     /**
      * @param  array<string, mixed>  $settings
      */
-    public function __construct(string $host, ?string $port = null, array $settings = [], int $mode = SWOOLE_PROCESS, ?Container $container = null)
-    {
+    public function __construct(
+        string $host,
+        ?string $port = null,
+        array $settings = [],
+        int $mode = SWOOLE_PROCESS,
+        protected Container $resources = new Container(),
+    ) {
         $this->server = new SwooleServer($host, (int) $port, $mode);
         $this->server->set($settings);
-        $this->container = $container ?? new Container();
     }
 
     public function onRequest(callable $callback): void
     {
         $this->server->on('request', function (SwooleRequest $request, SwooleResponse $response) use ($callback) {
-            $requestContainer = new Container($this->container);
-            $requestContainer->set('swooleRequest', fn() => $request);
-            $requestContainer->set('swooleResponse', fn() => $response);
+            $context = new Container($this->resources);
+            $context->set('swooleRequest', fn() => $request);
+            $context->set('swooleResponse', fn() => $response);
 
-            Coroutine::getContext()[self::REQUEST_CONTAINER_CONTEXT_KEY] = $requestContainer;
+            Coroutine::getContext()[self::CONTEXT_KEY] = $context;
 
             \call_user_func($callback, new Request($request), new Response($response));
         });
     }
 
-    public function getContainer(): Container
+    public function resources(): Container
+    {
+        return $this->resources;
+    }
+
+    public function context(): Container
     {
         if (Coroutine::getCid() !== -1) {
-            return Coroutine::getContext()[self::REQUEST_CONTAINER_CONTEXT_KEY] ?? $this->container;
+            return Coroutine::getContext()[self::CONTEXT_KEY] ?? $this->resources;
         }
 
-        return $this->container;
+        return $this->resources;
     }
 
     public function getServer(): SwooleServer

--- a/src/Http/Adapter/SwooleCoroutine/Server.php
+++ b/src/Http/Adapter/SwooleCoroutine/Server.php
@@ -11,10 +11,9 @@ use Utopia\Http\Adapter;
 
 class Server extends Adapter
 {
-    protected const string REQUEST_CONTAINER_CONTEXT_KEY = '__utopia_http_request_container';
+    protected const string CONTEXT_KEY = '__utopia__';
 
     protected SwooleServer $server;
-    protected Container $container;
 
     /** @var callable|null */
     protected $onStartCallback;
@@ -26,33 +25,37 @@ class Server extends Adapter
         string $host,
         ?string $port = null,
         array $settings = [],
-        ?Container $container = null,
+        protected Container $resources = new Container(),
     ) {
         $this->server = new SwooleServer($host, $port, false, true);
         $this->server->set($settings);
-        $this->container = $container ?? new Container();
     }
 
     public function onRequest(callable $callback): void
     {
         $this->server->handle('/', function (SwooleRequest $request, SwooleResponse $response) use ($callback) {
-            $requestContainer = new Container($this->container);
-            $requestContainer->set('swooleRequest', fn() => $request);
-            $requestContainer->set('swooleResponse', fn() => $response);
+            $context = new Container($this->resources);
+            $context->set('swooleRequest', fn() => $request);
+            $context->set('swooleResponse', fn() => $response);
 
-            Coroutine::getContext()[self::REQUEST_CONTAINER_CONTEXT_KEY] = $requestContainer;
+            Coroutine::getContext()[self::CONTEXT_KEY] = $context;
 
             try {
                 \call_user_func($callback, new Request($request), new Response($response));
             } finally {
-                unset(Coroutine::getContext()[self::REQUEST_CONTAINER_CONTEXT_KEY]);
+                unset(Coroutine::getContext()[self::CONTEXT_KEY]);
             }
         });
     }
 
-    public function getContainer(): Container
+    public function resources(): Container
     {
-        return Coroutine::getContext()[self::REQUEST_CONTAINER_CONTEXT_KEY] ?? $this->container;
+        return $this->resources;
+    }
+
+    public function context(): Container
+    {
+        return Coroutine::getContext()[self::CONTEXT_KEY] ?? $this->resources;
     }
 
     public function getServer(): SwooleServer

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -2,8 +2,6 @@
 
 namespace Utopia\Http;
 
-use Psr\Container\ContainerExceptionInterface;
-use Psr\Container\NotFoundExceptionInterface;
 use Utopia\DI\Container;
 use Utopia\Servers\Hook;
 use Utopia\Telemetry\Adapter as Telemetry;
@@ -44,11 +42,6 @@ class Http
 
     public const string MODE_TYPE_PRODUCTION = 'production';
 
-    protected Files $files;
-
-    protected Container $container;
-
-    protected ?Container $requestContainer = null;
 
     /**
      * Current running mode
@@ -135,17 +128,15 @@ class Http
 
     private Histogram $responseBodySize;
 
-    protected Adapter $server;
-
     /**
      * Http
      */
-    public function __construct(Adapter $server, string $timezone)
-    {
+    public function __construct(
+        protected Adapter $adapter,
+        string $timezone,
+        protected Files $files = new Files(),
+    ) {
         date_default_timezone_set($timezone);
-        $this->files = new Files();
-        $this->server = $server;
-        $this->container = $server->getContainer();
         $this->setTelemetry(new NoTelemetry());
     }
 
@@ -365,63 +356,28 @@ class Http
     }
 
     /**
-     * Get a single resource from the given scope.
+     * Static resources container.
      *
-     * @throws Exception
+     * Shortcut for the underlying adapter's {@see Adapter::resources()}. Use
+     * `$http->resources()->set(...)` to register app-wide services that are
+     * shared across every request for the lifetime of the server.
      */
-    public function getResource(string $name): mixed
+    public function resources(): Container
     {
-        try {
-            return $this->server->getContainer()->get($name);
-        } catch (ContainerExceptionInterface|NotFoundExceptionInterface $e) {
-            // Normalize DI container errors to the Http layer's "resource" terminology.
-            $message = str_replace('dependency', 'resource', $e->getMessage());
-
-            if ($message === $e->getMessage() && !str_contains($message, 'resource')) {
-                $message = 'Failed to find resource: "' . $name . '"';
-            }
-
-            throw new Exception($message, 500, $e);
-        }
+        return $this->adapter->resources();
     }
 
     /**
-     * Get multiple resources from the given scope.
+     * Per-request context container.
      *
-     * @param string[] $list
-     * @return array<string, mixed>
-     *
-     * @throws Exception
+     * Shortcut for the underlying adapter's {@see Adapter::context()}. Use
+     * `$http->context()->set(...)` to register request-scoped resources and
+     * `$http->context()->get(...)` to read them. Lookups fall through to the
+     * static resources container, so app-wide services remain accessible.
      */
-    public function getResources(array $list): array
+    public function context(): Container
     {
-        $resources = [];
-
-        foreach ($list as $name) {
-            $resources[$name] = $this->getResource($name);
-        }
-
-        return $resources;
-    }
-
-    /**
-     * Set a resource on the given scope.
-     *
-     * @param list<string> $injections
-     */
-    public function setResource(string $name, callable $callback, array $injections = []): void
-    {
-        $this->container->set($name, $callback, $injections);
-    }
-
-    /**
-     * Set a request-scoped resource on the current request's container.
-     *
-     * @param list<string> $injections
-     */
-    protected function setRequestResource(string $name, callable $callback, array $injections = []): void
-    {
-        $this->server->getContainer()->set($name, $callback, $injections);
+        return $this->adapter->context();
     }
 
     /**
@@ -550,12 +506,12 @@ class Http
     public function start(): void
     {
 
-        $this->server->onRequest(
+        $this->adapter->onRequest(
             fn(Request $request, Response $response) => $this->run($request, $response),
         );
 
-        $this->server->onStart(function ($server) {
-            $this->setResource('server', fn() => $server);
+        $this->adapter->onStart(function ($server) {
+            $this->resources()->set('server', fn() => $server);
             try {
 
                 foreach (self::$startHooks as $hook) {
@@ -563,7 +519,7 @@ class Http
                     \call_user_func_array($hook->getAction(), $arguments);
                 }
             } catch (\Exception $e) {
-                $this->setResource('error', fn() => $e);
+                $this->resources()->set('error', fn() => $e);
 
                 foreach (self::$errors as $error) { // Global error hooks
                     if (\in_array('*', $error->getGroups())) {
@@ -578,7 +534,7 @@ class Http
             }
         });
 
-        $this->server->start();
+        $this->adapter->start();
     }
 
     /**
@@ -657,7 +613,7 @@ class Http
                 }
             }
         } catch (\Throwable $e) {
-            $this->setRequestResource('error', fn() => $e, []);
+            $this->context()->set('error', fn() => $e, []);
 
             foreach ($groups as $group) {
                 foreach (self::$errors as $error) { // Group error hooks
@@ -725,7 +681,8 @@ class Http
 
             $arg = $existsInRequest ? $requestParams[$requestKey] : $param['default'];
             if (\is_callable($arg) && !\is_string($arg)) {
-                $arg = \call_user_func_array($arg, array_values($this->getResources($param['injections'])));
+                $context = $this->adapter->context();
+                $arg = \call_user_func_array($arg, array_map(fn($name) => $context->get($name), $param['injections']));
             }
             $value = $existsInValues ? $values[$valuesKey] : $arg;
 
@@ -744,7 +701,7 @@ class Http
         }
 
         foreach ($hook->getInjections() as $injection) {
-            $arguments[$injection['order']] = $this->getResource($injection['name']);
+            $arguments[$injection['order']] = $this->adapter->context()->get($injection['name']);
         }
 
         return $arguments;
@@ -797,8 +754,8 @@ class Http
             $response->setCompressionSupported($this->compressionSupported);
         }
 
-        $this->setRequestResource('request', fn() => $request);
-        $this->setRequestResource('response', fn() => $response);
+        $this->context()->set('request', fn() => $request);
+        $this->context()->set('response', fn() => $response);
 
         try {
             foreach (self::$requestHooks as $hook) {
@@ -806,7 +763,7 @@ class Http
                 \call_user_func_array($hook->getAction(), $arguments);
             }
         } catch (\Exception $e) {
-            $this->setRequestResource('error', fn() => $e, []);
+            $this->context()->set('error', fn() => $e, []);
 
             foreach (self::$errors as $error) { // Global error hooks
                 if (\in_array('*', $error->getGroups())) {
@@ -836,7 +793,7 @@ class Http
         $route = $this->match($request);
         $groups = ($route instanceof Route) ? $route->getGroups() : [];
 
-        $this->setRequestResource('route', fn() => $route, []);
+        $this->context()->set('route', fn() => $route, []);
 
         if (self::REQUEST_METHOD_HEAD === $method) {
             $method = self::REQUEST_METHOD_GET;
@@ -864,7 +821,7 @@ class Http
                 foreach (self::$errors as $error) { // Global error hooks
                     /** @var Hook $error */
                     if (\in_array('*', $error->getGroups())) {
-                        $this->setRequestResource('error', fn() => $e, []);
+                        $this->context()->set('error', fn() => $e, []);
                         \call_user_func_array($error->getAction(), $this->getArguments($error, [], $request->getParams()));
                     }
                 }
@@ -880,7 +837,7 @@ class Http
             $path = \is_string($path) ? ($path === '' ? '/' : $path) : '/';
             $route->path($path);
 
-            $this->setRequestResource('route', fn() => $route, []);
+            $this->context()->set('route', fn() => $route, []);
         }
         if (null !== $route) {
             return $this->execute($route, $request, $response);
@@ -904,7 +861,7 @@ class Http
             } catch (\Throwable $e) {
                 foreach (self::$errors as $error) { // Global error hooks
                     if (\in_array('*', $error->getGroups())) {
-                        $this->setRequestResource('error', fn() => $e, []);
+                        $this->context()->set('error', fn() => $e, []);
                         \call_user_func_array($error->getAction(), $this->getArguments($error, [], $request->getParams()));
                     }
                 }
@@ -912,7 +869,7 @@ class Http
         } else {
             foreach (self::$errors as $error) { // Global error hooks
                 if (\in_array('*', $error->getGroups())) {
-                    $this->setRequestResource('error', fn() => new Exception('Not Found', 404), []);
+                    $this->context()->set('error', fn() => new Exception('Not Found', 404), []);
                     \call_user_func_array($error->getAction(), $this->getArguments($error, [], $request->getParams()));
                 }
             }
@@ -940,7 +897,8 @@ class Http
         $validator = $param['validator']; // checking whether the class exists
 
         if (\is_callable($validator)) {
-            $validator = \call_user_func_array($validator, array_values($this->getResources($param['injections'])));
+            $context = $this->adapter->context();
+            $validator = \call_user_func_array($validator, array_map(fn($name) => $context->get($name), $param['injections']));
         }
 
         if (!$validator instanceof Validator) { // is the validator object an instance of the Validator class

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -682,7 +682,7 @@ class Http
             $arg = $existsInRequest ? $requestParams[$requestKey] : $param['default'];
             if (\is_callable($arg) && !\is_string($arg)) {
                 $context = $this->adapter->context();
-                $arg = \call_user_func_array($arg, array_map(fn($name) => $context->get($name), $param['injections']));
+                $arg = \call_user_func_array($arg, array_map($context->get(...), $param['injections']));
             }
             $value = $existsInValues ? $values[$valuesKey] : $arg;
 
@@ -898,7 +898,7 @@ class Http
 
         if (\is_callable($validator)) {
             $context = $this->adapter->context();
-            $validator = \call_user_func_array($validator, array_map(fn($name) => $context->get($name), $param['injections']));
+            $validator = \call_user_func_array($validator, array_map($context->get(...), $param['injections']));
         }
 
         if (!$validator instanceof Validator) { // is the validator object an instance of the Validator class

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -17,7 +17,7 @@ final class HttpTest extends TestCase
 {
     protected ?Http $http;
 
-    protected ?Container $container;
+    protected ?Container $resources;
 
     protected ?string $method;
 
@@ -26,15 +26,15 @@ final class HttpTest extends TestCase
     public function setUp(): void
     {
         Http::reset();
-        $this->container = new Container();
-        $this->http = new Http(new Server($this->container), 'Asia/Tel_Aviv');
+        $this->resources = new Container();
+        $this->http = new Http(new Server($this->resources), 'Asia/Tel_Aviv');
         $this->saveRequest();
     }
 
     public function tearDown(): void
     {
         $this->http = null;
-        $this->container = null;
+        $this->resources = null;
         $this->restoreRequest();
     }
 
@@ -90,8 +90,8 @@ final class HttpTest extends TestCase
 
     public function testCanExecuteRoute(): void
     {
-        $this->container->set('rand', fn() => rand());
-        $resource = $this->container->get('rand');
+        $this->resources->set('rand', fn() => rand());
+        $resource = $this->resources->get('rand');
 
         $this->http
             ->error()
@@ -116,7 +116,7 @@ final class HttpTest extends TestCase
         ob_end_clean();
 
         // With Params
-        $resource = $this->container->get('rand');
+        $resource = $this->resources->get('rand');
         $route = new Route('GET', '/path');
 
         $route
@@ -142,7 +142,7 @@ final class HttpTest extends TestCase
         $this->assertSame($resource . '-param-x-param-y', $result);
 
         // With Error
-        $resource = $this->container->get('rand');
+        $resource = $this->resources->get('rand');
         $route = new Route('GET', '/path');
 
         $route
@@ -162,7 +162,7 @@ final class HttpTest extends TestCase
         $this->assertSame('error: Invalid `x` param: Value must be a valid string and no longer than 1 chars', $result);
 
         // With Hooks
-        $resource = $this->container->get('rand');
+        $resource = $this->resources->get('rand');
         $this->http
             ->init()
             ->inject('rand')
@@ -233,7 +233,7 @@ final class HttpTest extends TestCase
 
         $this->assertSame('init-' . $resource . '-(init-api)-param-x-param-y-(shutdown-api)-shutdown', $result);
 
-        $resource = $this->container->get('rand');
+        $resource = $this->resources->get('rand');
         ob_start();
         $request = new UtopiaFPMRequestTest();
         $request::_setParams(['x' => 'param-x', 'y' => 'param-y']);
@@ -722,7 +722,7 @@ final class HttpTest extends TestCase
         Http::init()
             ->action(function () {
                 $route = $this->http->getRoute();
-                $this->container->set('myRoute', fn() => $route);
+                $this->resources->set('myRoute', fn() => $route);
             });
 
 
@@ -841,7 +841,7 @@ final class HttpTest extends TestCase
     {
         // Register a 'locale' resource returning a Locale instance whose
         // `name` statically resolves to "en".
-        $this->container->set('locale', fn() => new Locale());
+        $this->resources->set('locale', fn() => new Locale());
 
         $route = new Route('GET', '/path');
 


### PR DESCRIPTION
## Summary

Reworks how DI containers are exposed by the HTTP layer. The previous single `getContainer()` API conflated two distinct lifetimes — long-lived "boot the server" wiring and short-lived per-request state. This PR makes the split explicit:

- **`resources()`** — static container, shared across every request for the lifetime of the server. Use this at boot to register config, clients, and shared services.
- **`context()`** — per-request child container, created fresh on each incoming request. Lookups fall through to `resources()`, so static services remain reachable from request handlers. The library writes `request`, `response`, `route`, and `error` into this container.

The internal coroutine context key is now `__utopia__`.

## Breaking changes

### `Adapter`

| Before | After |
| --- | --- |
| `getContainer(): Container` | **removed** — replaced by the two methods below |
| — | `resources(): Container` |
| — | `context(): Container` |

Both new methods are abstract and documented on `Utopia\Http\Adapter`. All three bundled adapters (`FPM`, `Swoole`, `SwooleCoroutine`) implement both.

### Adapter constructors

The container parameter has been renamed from `$container` to `$resources` and is now a constructor-promoted property on every adapter:

```php
// FPM
new FPM\Server(Container $resources)

// Swoole
new Swoole\Server(
    string $host,
    ?string $port = null,
    array $settings = [],
    int $mode = SWOOLE_PROCESS,
    Container $resources = new Container(),
)

// SwooleCoroutine
new SwooleCoroutine\Server(
    string $host,
    ?string $port = null,
    array $settings = [],
    Container $resources = new Container(),
)
```

If you were passing the container positionally to the Swoole adapters this still works. If you were passing it by name, rename `container:` → `resources:`.

### `Http`

| Before | After |
| --- | --- |
| `new Http(Adapter $server, string $timezone, ?Container $container = null)` | `new Http(Adapter $adapter, string $timezone, Files $files = new Files())` |
| `Http::getResource(string $name): mixed` | **removed** — use `$http->context()->get($name)` |
| `Http::getResources(array $list): array` | **removed** — call `$http->context()->get(...)` per name |
| `Http::setResource(string $name, callable $cb, array $injections = [])` | **removed** — use `$http->resources()->set(...)` |
| — | `Http::resources(): Container` (shortcut to `$adapter->resources()`) |
| — | `Http::context(): Container` (shortcut to `$adapter->context()`) |

The `Http` constructor no longer accepts a container — pass it to the adapter instead. The internal `$server` field has been renamed to `$adapter` to match the parameter type.

`Http::getResource()` previously normalized DI errors into `Utopia\Http\Exception` with a "resource"-flavored message. That normalization is gone; lookups now surface the underlying `Utopia\DI` exceptions directly.

### Migration

```php
// Before
$container = new Container();
$container->set('db', fn() => new Database());

$http = new Http(new Server(), 'UTC', $container);
$http->setResource('cache', fn() => new Cache());
$db = $http->getResource('db');

// After
$resources = new Container();
$resources->set('db', fn() => new Database());

$http = new Http(new Server($resources), 'UTC');
$http->resources()->set('cache', fn() => new Cache());
$db = $http->context()->get('db'); // falls through to resources
```

## Non-breaking cleanup

- `Http` constructor uses property promotion for `$adapter` and `$files`.
- Removed the unused `Psr\Container\*Exception` imports (no more error normalization).
- README examples updated to the new constructor shapes and `$resources` naming.
- Test fixture `$this->container` renamed to `$this->resources`.

## Test plan

- [ ] `composer test` passes locally
- [ ] Smoke test FPM adapter against the example app
- [ ] Smoke test Swoole adapter against the example app
- [ ] Verify a downstream consumer (e.g. Appwrite) compiles against the new API and migration steps cover the changes encountered

🤖 Generated with [Claude Code](https://claude.com/claude-code)