### PR TITLE
Feat: PSR-compliant headers and cookies on Request/Response

### DIFF
--- a/src/Http/Adapter/FPM/Request.php
+++ b/src/Http/Adapter/FPM/Request.php
@@ -59,7 +59,7 @@ class Request extends UtopiaRequest
         $remoteAddr = $this->getServer('REMOTE_ADDR') ?? '0.0.0.0';
 
         foreach ($this->trustedIpHeaders as $header) {
-            $headerValue = $this->getHeader($header);
+            $headerValue = $this->getHeaderLine($header);
 
             if (empty($headerValue)) {
                 continue;
@@ -209,57 +209,19 @@ class Request extends UtopiaRequest
     }
 
     /**
-     * Get cookie
+     * Generate cookies
      *
-     * Method for querying HTTP cookie parameters. If $key is not found $default value will be returned.
-     */
-    public function getCookie(string $key, string $default = ''): string
-    {
-        return $_COOKIE[$key] ?? $default;
-    }
-
-    /**
-     * Get header
+     * Parse request cookies into an associative array of cookie name to value.
      *
-     * Method for querying HTTP header parameters. If $key is not found $default value will be returned.
+     * @return array<string, string>
      */
-    public function getHeader(string $key, string $default = ''): string
+    protected function generateCookies(): array
     {
-        $headers = $this->generateHeaders();
-
-        if (!isset($headers[$key])) {
-            return $default;
+        if (null === $this->cookies) {
+            $this->cookies = $_COOKIE;
         }
 
-        $value = $headers[$key];
-
-        return \is_array($value) ? implode(', ', $value) : $value;
-    }
-
-    /**
-     * Set header
-     *
-     * Method for adding HTTP header parameters.
-     */
-    public function addHeader(string $key, string $value): static
-    {
-        $this->headers[$key] = $value;
-
-        return $this;
-    }
-
-    /**
-     * Remvoe header
-     *
-     * Method for removing HTTP header parameters.
-     */
-    public function removeHeader(string $key): static
-    {
-        if (isset($this->headers[$key])) {
-            unset($this->headers[$key]);
-        }
-
-        return $this;
+        return $this->cookies;
     }
 
     /**
@@ -275,7 +237,7 @@ class Request extends UtopiaRequest
             $this->queryString = $_GET;
         }
         if (null === $this->payload) {
-            $contentType = $this->getHeader('content-type');
+            $contentType = $this->getHeaderLine('content-type');
 
             // Get content-type without the charset
             $length = strpos($contentType, ';');
@@ -301,40 +263,5 @@ class Request extends UtopiaRequest
             self::METHOD_DELETE => $this->payload,
             default => $this->queryString,
         };
-    }
-
-    /**
-     * Generate headers
-     *
-     * Parse request headers as an array for easy querying using the getHeader method
-     *
-     * @return array<string, string|array<int, string>>
-     */
-    #[\Override]
-    protected function generateHeaders(): array
-    {
-        if (null === $this->headers) {
-            /**
-             * Fallback for older PHP versions
-             * that do not support generateHeaders
-             */
-            if (!\function_exists('getallheaders')) {
-                $headers = [];
-
-                foreach ($_SERVER as $name => $value) {
-                    if (str_starts_with($name, 'HTTP_')) {
-                        $headers[str_replace(' ', '-', strtolower(str_replace('_', ' ', substr($name, 5))))] = $value;
-                    }
-                }
-
-                $this->headers = $headers;
-
-                return $this->headers;
-            }
-
-            $this->headers = array_change_key_case(getallheaders());
-        }
-
-        return $this->headers;
     }
 }

--- a/src/Http/Adapter/FPM/Response.php
+++ b/src/Http/Adapter/FPM/Response.php
@@ -45,18 +45,22 @@ class Response extends UtopiaResponse
     /**
      * Send Header
      *
-     * Output Header
+     * Output Header. Header names are stored lowercased internally; they are
+     * formatted to the conventional Title-Case form on the wire to match the
+     * Swoole adapter (e.g. "content-type" => "Content-Type").
      *
-     * @param  string|array<string>  $value
+     * @param  array<int, string>  $value
      */
-    public function sendHeader(string $key, mixed $value): void
+    public function sendHeader(string $key, array $value): void
     {
-        if (\is_array($value)) {
-            foreach ($value as $v) {
-                header($key . ': ' . $v, false);
-            }
-        } else {
-            header($key . ': ' . $value);
+        $key = ucwords(strtolower($key), '-');
+
+        // First value replaces any header of the same name; the rest are
+        // appended so multi-value headers (e.g. Set-Cookie) emit one line each.
+        $replace = true;
+        foreach ($value as $v) {
+            header($key . ': ' . $v, $replace);
+            $replace = false;
         }
     }
 
@@ -69,11 +73,15 @@ class Response extends UtopiaResponse
      */
     protected function sendCookie(string $name, string $value, array $options): void
     {
-        // Use proper PHP keyword name
-        $options['expires'] = $options['expire'];
-        unset($options['expire']);
-
-        // Set the cookie
-        setcookie($name, $value, $options);
+        // Coalesce nulls to the types setcookie() expects for each option, and
+        // map our 'expire' key to PHP's 'expires' keyword.
+        setcookie($name, $value, [
+            'expires' => $options['expire'] ?? 0,
+            'path' => $options['path'] ?? '',
+            'domain' => $options['domain'] ?? '',
+            'secure' => $options['secure'] ?? false,
+            'httponly' => $options['httponly'] ?? false,
+            'samesite' => $options['samesite'] ?? '',
+        ]);
     }
 }

--- a/src/Http/Adapter/Swoole/Request.php
+++ b/src/Http/Adapter/Swoole/Request.php
@@ -64,7 +64,7 @@ class Request extends UtopiaRequest
         $remoteAddr = $this->getServer('remote_addr') ?? '0.0.0.0';
 
         foreach ($this->trustedIpHeaders as $header) {
-            $headerValue = $this->getHeader($header);
+            $headerValue = $this->getHeaderLine($header);
 
             if (empty($headerValue)) {
                 continue;
@@ -92,7 +92,7 @@ class Request extends UtopiaRequest
      */
     public function getProtocol(): string
     {
-        $protocol = $this->getHeader('x-forwarded-proto', $this->getServer('server_protocol') ?? 'https');
+        $protocol = $this->getHeaderLine('x-forwarded-proto', $this->getServer('server_protocol') ?? 'https');
 
         if ($protocol === 'HTTP/1.1') {
             return 'http';
@@ -111,7 +111,7 @@ class Request extends UtopiaRequest
      */
     public function getPort(): string
     {
-        return $this->getHeader('x-forwarded-port', (string) parse_url($this->getProtocol() . '://' . $this->getHeader('x-forwarded-host', $this->getHeader('host')), PHP_URL_PORT));
+        return $this->getHeaderLine('x-forwarded-port', (string) parse_url($this->getProtocol() . '://' . $this->getHeaderLine('x-forwarded-host', $this->getHeaderLine('host')), PHP_URL_PORT));
     }
 
     /**
@@ -121,7 +121,7 @@ class Request extends UtopiaRequest
      */
     public function getHostname(): string
     {
-        $hostname = parse_url($this->getProtocol() . '://' . $this->getHeader('x-forwarded-host', $this->getHeader('host')), PHP_URL_HOST);
+        $hostname = parse_url($this->getProtocol() . '://' . $this->getHeaderLine('x-forwarded-host', $this->getHeaderLine('host')), PHP_URL_HOST);
         return strtolower(\strval($hostname));
     }
 
@@ -177,7 +177,7 @@ class Request extends UtopiaRequest
      */
     public function getReferer(string $default = ''): string
     {
-        return $this->getHeader('referer', '');
+        return $this->getHeaderLine('referer', $default);
     }
 
     /**
@@ -187,7 +187,7 @@ class Request extends UtopiaRequest
      */
     public function getOrigin(string $default = ''): string
     {
-        return $this->getHeader('origin', $default);
+        return $this->getHeaderLine('origin', $default);
     }
 
     /**
@@ -197,7 +197,7 @@ class Request extends UtopiaRequest
      */
     public function getUserAgent(string $default = ''): string
     {
-        return $this->getHeader('user-agent', $default);
+        return $this->getHeaderLine('user-agent', $default);
     }
 
     /**
@@ -207,7 +207,7 @@ class Request extends UtopiaRequest
      */
     public function getAccept(string $default = ''): string
     {
-        return $this->getHeader('accept', $default);
+        return $this->getHeaderLine('accept', $default);
     }
 
     /**
@@ -226,47 +226,19 @@ class Request extends UtopiaRequest
     }
 
     /**
-     * Get cookie
+     * Generate cookies
      *
-     * Method for querying HTTP cookie parameters. If $key is not found $default value will be returned.
-     */
-    public function getCookie(string $key, string $default = ''): string
-    {
-        $key = strtolower($key);
-
-        return $this->swoole->cookie[$key] ?? $default;
-    }
-
-    /**
-     * Get header
+     * Parse request cookies into an associative array of cookie name to value.
      *
-     * Method for querying HTTP header parameters. If $key is not found $default value will be returned.
+     * @return array<string, string>
      */
-    public function getHeader(string $key, string $default = ''): string
+    protected function generateCookies(): array
     {
-        return $this->swoole->header[$key] ?? $default;
-    }
-
-    /**
-     * Method for adding HTTP header parameters.
-     */
-    public function addHeader(string $key, string $value): static
-    {
-        $this->swoole->header[$key] = $value;
-
-        return $this;
-    }
-
-    /**
-     * Method for removing HTTP header parameters.
-     */
-    public function removeHeader(string $key): static
-    {
-        if (isset($this->swoole->header[$key])) {
-            unset($this->swoole->header[$key]);
+        if (null === $this->cookies) {
+            $this->cookies = $this->swoole->cookie ?? [];
         }
 
-        return $this;
+        return $this->cookies;
     }
 
     public function getSwooleRequest(): SwooleRequest
@@ -287,7 +259,7 @@ class Request extends UtopiaRequest
             $this->queryString = $this->swoole->get ?? [];
         }
         if (null === $this->payload) {
-            $contentType = $this->getHeader('content-type');
+            $contentType = $this->getHeaderLine('content-type');
 
             // Get content-type without the charset
             $length = strpos($contentType, ';');
@@ -316,13 +288,26 @@ class Request extends UtopiaRequest
     /**
      * Generate headers
      *
-     * Parse request headers as an array for easy querying using the getHeader method
+     * Parse Swoole request headers into a PSR-7 style map of lowercased header name
+     * to a list of string values for easy querying using the getHeader method.
      *
-     * @return array<string, mixed>
+     * @return array<string, array<int, string>>
      */
     #[\Override]
     protected function generateHeaders(): array
     {
-        return $this->swoole->header;
+        if (null === $this->headers) {
+            $headers = [];
+
+            foreach ($this->swoole->header ?? [] as $name => $value) {
+                $headers[strtolower($name)] = \is_array($value)
+                    ? array_values(array_map(strval(...), $value))
+                    : [(string) $value];
+            }
+
+            $this->headers = $headers;
+        }
+
+        return $this->headers;
     }
 }

--- a/src/Http/Adapter/Swoole/Response.php
+++ b/src/Http/Adapter/Swoole/Response.php
@@ -57,9 +57,9 @@ class Response extends UtopiaResponse
     /**
      * Send Header
      *
-     * @param  string|array<string>  $value
+     * @param  array<int, string>  $value
      */
-    public function sendHeader(string $key, mixed $value): void
+    public function sendHeader(string $key, array $value): void
     {
         $this->swoole->header($key, $value);
     }
@@ -73,6 +73,8 @@ class Response extends UtopiaResponse
      */
     protected function sendCookie(string $name, string $value, array $options): void
     {
+        // Coalesce nulls to the types Swoole's cookie() expects: the SameSite
+        // argument is parsed as a string (Z_PARAM_STR), so it must not be a bool.
         $this->swoole->cookie(
             $name,
             $value,
@@ -81,7 +83,7 @@ class Response extends UtopiaResponse
             $options['domain'] ?? '',
             $options['secure'] ?? false,
             $options['httponly'] ?? false,
-            $options['samesite'] ?? false,
+            $options['samesite'] ?? '',
         );
     }
 }

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -791,7 +791,7 @@ class Http
     private function runInternal(Request $request, Response $response): static
     {
         if ($this->compression) {
-            $response->setAcceptEncoding($request->getHeader('accept-encoding', ''));
+            $response->setAcceptEncoding($request->getHeaderLine('accept-encoding', ''));
             $response->setCompressionMinSize($this->compressionMinSize);
             $response->setCompressionSupported($this->compressionSupported);
         }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -42,9 +42,19 @@ abstract class Request
     /**
      * Container for parsed headers
      *
-     * @var array<string, string|array<int, string>>|null
+     * Each header is stored under its lowercased name and maps to a list of
+     * one or more string values, following the PSR-7 header representation.
+     *
+     * @var array<string, array<int, string>>|null
      */
-    protected $headers;
+    protected ?array $headers = null;
+
+    /**
+     * Container for parsed cookies
+     *
+     * @var array<string, string>|null
+     */
+    protected ?array $cookies = null;
 
     /**
      * @var array<int, string>
@@ -240,23 +250,93 @@ abstract class Request
     /**
      * Get cookie
      *
-     * Method for querying HTTP cookie parameters. If $key is not found $default value will be returned.
+     * Method for querying a single HTTP cookie. If $key is not found $default value will be returned.
      */
-    abstract public function getCookie(string $key, string $default = ''): string;
+    public function getCookie(string $key, string $default = ''): string
+    {
+        $cookies = $this->generateCookies();
+
+        return $cookies[$key] ?? $default;
+    }
+
+    /**
+     * Get cookie params
+     *
+     * Method for getting all HTTP cookies as an associative array, following PSR-7.
+     *
+     * @return array<string, string>
+     */
+    public function getCookieParams(): array
+    {
+        return $this->generateCookies();
+    }
+
+    /**
+     * Set cookie params
+     *
+     * Replace the request cookies with the given associative array, following PSR-7.
+     *
+     * @param  array<string, string>  $cookies
+     */
+    public function setCookieParams(array $cookies): static
+    {
+        $this->cookies = $cookies;
+
+        return $this;
+    }
+
+    /**
+     * Has header
+     *
+     * Checks if a header exists by the given case-insensitive name, following PSR-7.
+     */
+    public function hasHeader(string $key): bool
+    {
+        $headers = $this->generateHeaders();
+
+        return isset($headers[strtolower($key)]);
+    }
 
     /**
      * Get header
      *
-     * Method for querying HTTP header parameters. If $key is not found $default value will be returned.
+     * Method for querying all values of a single HTTP header by its case-insensitive
+     * name, following PSR-7. Returns a list of strings, or $default when not found.
+     *
+     * @param  array<int, string>  $default
+     * @return array<int, string>
      */
-    abstract public function getHeader(string $key, string $default = ''): string;
+    public function getHeader(string $key, array $default = []): array
+    {
+        $headers = $this->generateHeaders();
+
+        return $headers[strtolower($key)] ?? $default;
+    }
+
+    /**
+     * Get header line
+     *
+     * Returns all values for the given case-insensitive header name concatenated
+     * using a comma, following PSR-7. Returns $default when the header is not found.
+     */
+    public function getHeaderLine(string $key, string $default = ''): string
+    {
+        $values = $this->getHeader($key);
+
+        if ($values === []) {
+            return $default;
+        }
+
+        return implode(', ', $values);
+    }
 
     /**
      * Get headers
      *
-     * Method for getting all HTTP header parameters.
+     * Method for getting all HTTP headers as an associative array of header name
+     * to a list of string values, following PSR-7.
      *
-     * @return array<string,mixed>
+     * @return array<string, array<int, string>>
      */
     public function getHeaders(): array
     {
@@ -266,16 +346,43 @@ abstract class Request
     /**
      * Set header
      *
-     * Method for adding HTTP header parameters.
+     * Replace any existing values for the given header with a single value,
+     * mirroring PSR-7's withHeader.
      */
-    abstract public function addHeader(string $key, string $value): static;
+    public function setHeader(string $key, string $value): static
+    {
+        $this->generateHeaders();
+        $this->headers[strtolower($key)] = [$value];
+
+        return $this;
+    }
 
     /**
-     * Remvoe header
+     * Add header
      *
-     * Method for removing HTTP header parameters.
+     * Append a value to an existing header, or create it if it does not exist,
+     * mirroring PSR-7's withAddedHeader.
      */
-    abstract public function removeHeader(string $key): static;
+    public function addHeader(string $key, string $value): static
+    {
+        $this->generateHeaders();
+        $this->headers[strtolower($key)][] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Remove header
+     *
+     * Method for removing an HTTP header by its case-insensitive name.
+     */
+    public function removeHeader(string $key): static
+    {
+        $this->generateHeaders();
+        unset($this->headers[strtolower($key)]);
+
+        return $this;
+    }
 
     /**
      * Get Request Size
@@ -286,8 +393,8 @@ abstract class Request
     {
         $headers = $this->generateHeaders();
         $headerStrings = [];
-        foreach ($headers as $key => $value) {
-            $headerStrings[] = \is_array($value) ? $key . ': ' . implode(', ', $value) : $key . ': ' . $value;
+        foreach ($headers as $key => $values) {
+            $headerStrings[] = $key . ': ' . implode(', ', $values);
         }
         return mb_strlen(implode("\n", $headerStrings), '8bit') + mb_strlen(file_get_contents('php://input') ?: '', '8bit');
     }
@@ -420,36 +527,47 @@ abstract class Request
     /**
      * Generate headers
      *
-     * Parse request headers as an array for easy querying using the getHeader method
+     * Parse request headers into a PSR-7 style map of lowercased header name to a
+     * list of string values for easy querying using the getHeader method.
      *
-     * @return array<string, string|array<int, string>>
+     * @return array<string, array<int, string>>
      */
     protected function generateHeaders(): array
     {
         if (null === $this->headers) {
+            $headers = [];
+
             /**
-             * Fallback for older PHP versions
-             * that do not support generateHeaders
+             * Fallback for environments
+             * that do not support getallheaders
              */
             if (!\function_exists('getallheaders')) {
-                $headers = [];
-
                 foreach ($_SERVER as $name => $value) {
                     if (str_starts_with($name, 'HTTP_')) {
-                        $headers[str_replace(' ', '-', strtolower(str_replace('_', ' ', substr($name, 5))))] = $value;
+                        $key = str_replace(' ', '-', strtolower(str_replace('_', ' ', substr($name, 5))));
+                        $headers[$key] = [(string) $value];
                     }
                 }
-
-                $this->headers = $headers;
-
-                return $this->headers;
+            } else {
+                foreach (getallheaders() as $name => $value) {
+                    $headers[strtolower($name)] = [(string) $value];
+                }
             }
 
-            $this->headers = array_change_key_case(getallheaders());
+            $this->headers = $headers;
         }
 
         return $this->headers;
     }
+
+    /**
+     * Generate cookies
+     *
+     * Parse request cookies into an associative array of cookie name to value.
+     *
+     * @return array<string, string>
+     */
+    abstract protected function generateCookies(): array;
 
     /**
      * Generate input
@@ -469,7 +587,7 @@ abstract class Request
      */
     protected function parseContentRange(): ?array
     {
-        $contentRange = $this->getHeader('content-range', '');
+        $contentRange = $this->getHeaderLine('content-range', '');
         $data = [];
         if (!empty($contentRange)) {
             $contentRange = explode(' ', $contentRange);
@@ -523,7 +641,7 @@ abstract class Request
      */
     protected function parseRange(): ?array
     {
-        $rangeHeader = $this->getHeader('range', '');
+        $rangeHeader = $this->getHeaderLine('range', '');
         if (empty($rangeHeader)) {
             return null;
         }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -272,7 +272,10 @@ abstract class Response
     protected bool $headersSent = false;
 
     /**
-     * @var array<string, string|array<string>>
+     * Response headers, stored under their lowercased name and mapping to a list of
+     * one or more string values, following the PSR-7 header representation.
+     *
+     * @var array<string, array<int, string>>
      */
     protected array $headers = [];
 
@@ -437,21 +440,27 @@ abstract class Response
     }
 
     /**
+     * Set header
+     *
+     * Replace any existing values for the given header with a single value,
+     * mirroring PSR-7's withHeader.
+     */
+    public function setHeader(string $key, string $value): static
+    {
+        $this->headers[strtolower($key)] = [$value];
+
+        return $this;
+    }
+
+    /**
      * Add header
      *
-     * Add an HTTP response header
+     * Append a value to an existing response header, or create it if it does not
+     * exist, mirroring PSR-7's withAddedHeader.
      */
     public function addHeader(string $key, string $value): static
     {
-        if (\array_key_exists($key, $this->headers)) {
-            if (\is_array($this->headers[$key])) {
-                $this->headers[$key][] = $value;
-            } else {
-                $this->headers[$key] = [$this->headers[$key], $value];
-            }
-        } else {
-            $this->headers[$key] = $value;
-        }
+        $this->headers[strtolower($key)][] = $value;
 
         return $this;
     }
@@ -459,23 +468,63 @@ abstract class Response
     /**
      * Remove header
      *
-     * Remove HTTP response header
+     * Remove an HTTP response header by its case-insensitive name.
      */
     public function removeHeader(string $key): static
     {
-        if (isset($this->headers[$key])) {
-            unset($this->headers[$key]);
-        }
+        unset($this->headers[strtolower($key)]);
 
         return $this;
     }
 
     /**
+     * Has header
+     *
+     * Checks if a response header exists by the given case-insensitive name, following PSR-7.
+     */
+    public function hasHeader(string $key): bool
+    {
+        return isset($this->headers[strtolower($key)]);
+    }
+
+    /**
+     * Get header
+     *
+     * Return all values of a single response header by its case-insensitive name,
+     * following PSR-7. Returns a list of strings, or $default when not found.
+     *
+     * @param  array<int, string>  $default
+     * @return array<int, string>
+     */
+    public function getHeader(string $key, array $default = []): array
+    {
+        return $this->headers[strtolower($key)] ?? $default;
+    }
+
+    /**
+     * Get header line
+     *
+     * Return all values for the given case-insensitive header name concatenated
+     * using a comma, following PSR-7. Returns $default when the header is not found.
+     */
+    public function getHeaderLine(string $key, string $default = ''): string
+    {
+        $values = $this->getHeader($key);
+
+        if ($values === []) {
+            return $default;
+        }
+
+        return implode(', ', $values);
+    }
+
+    /**
      * Get Headers
      *
-     * Return array of all response headers
+     * Return array of all response headers, each mapping to a list of string values,
+     * following PSR-7.
      *
-     * @return array<string, string|array<string>>
+     * @return array<string, array<int, string>>
      */
     public function getHeaders(): array
     {
@@ -542,17 +591,9 @@ abstract class Response
 
         $this->appendCookies();
 
-        $hasContentEncoding = false;
-        foreach ($this->headers as $name => $values) {
-            if (strtolower($name) === 'content-encoding') {
-                $hasContentEncoding = true;
-                break;
-            }
-        }
-
         // Compress body only if all conditions are met:
         if (
-            !$hasContentEncoding
+            !$this->hasHeader('Content-Encoding')
             && !empty($this->acceptEncoding)
             && $this->isCompressible($this->contentType)
             && \strlen($body) > $this->compressionMinSize
@@ -588,14 +629,10 @@ abstract class Response
 
         $headersSize = 0;
         foreach ($this->headers as $name => $values) {
-            if (\is_array($values)) {
-                foreach ($values as $value) {
-                    $headersSize += \strlen($name . ': ' . $value);
-                }
-                $headersSize += (\count($values) - 1) * 2; // linebreaks
-            } else {
-                $headersSize += \strlen($name . ': ' . $values);
+            foreach ($values as $value) {
+                $headersSize += \strlen($name . ': ' . $value);
             }
+            $headersSize += (\count($values) - 1) * 2; // linebreaks
         }
         $headersSize += (\count($this->headers) - 1) * 2; // linebreaks
 
@@ -684,12 +721,12 @@ abstract class Response
 
         // Send content type header
         if (!empty($this->contentType)) {
-            $this->addHeader('Content-Type', $this->contentType);
+            $this->setHeader('Content-Type', $this->contentType);
         }
 
         // Set application headers
-        foreach ($this->headers as $key => $value) {
-            $this->sendHeader($key, $value);
+        foreach ($this->headers as $key => $values) {
+            $this->sendHeader($key, $values);
         }
 
         return $this;
@@ -705,9 +742,9 @@ abstract class Response
      *
      * Output Header
      *
-     * @param  string|array<string>  $value
+     * @param  array<int, string>  $value
      */
-    abstract public function sendHeader(string $key, mixed $value): void;
+    abstract public function sendHeader(string $key, array $value): void;
 
     /**
      * Send Cookie
@@ -726,7 +763,9 @@ abstract class Response
     protected function appendCookies(): static
     {
         foreach ($this->cookies as $cookie) {
-            $this->sendCookie($cookie['name'], $cookie['value'], [
+            // A cookie may be registered without a value; send an empty string
+            // rather than passing null to the non-nullable $value parameter.
+            $this->sendCookie($cookie['name'], $cookie['value'] ?? '', [
                 'expire' => $cookie['expire'],
                 'path' => $cookie['path'],
                 'domain' => $cookie['domain'],

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -13,6 +13,17 @@ final class RequestTest extends TestCase
 
     public function setUp(): void
     {
+        // Reset request-related superglobals so each test starts from a clean state.
+        foreach (array_keys($_SERVER) as $key) {
+            if (str_starts_with($key, 'HTTP_')) {
+                unset($_SERVER[$key]);
+            }
+        }
+        unset($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI'], $_SERVER['REQUEST_SCHEME'], $_SERVER['key']);
+        $_GET = [];
+        $_POST = [];
+        $_COOKIE = [];
+
         $this->request = new Request();
     }
 
@@ -26,13 +37,25 @@ final class RequestTest extends TestCase
         $_SERVER['HTTP_CUSTOM'] = 'value1';
         $_SERVER['HTTP_CUSTOM_NEW'] = 'value2';
 
-        $this->assertSame('value1', $this->request->getHeader('custom'));
-        $this->assertSame('value2', $this->request->getHeader('custom-new'));
+        // Header lookups are case-insensitive and return a list of values (PSR-7).
+        $this->assertSame(['value1'], $this->request->getHeader('custom'));
+        $this->assertSame(['value2'], $this->request->getHeader('Custom-New'));
+
+        // getHeaderLine concatenates the values into a single string.
+        $this->assertSame('value1', $this->request->getHeaderLine('custom'));
+
+        // hasHeader reports presence case-insensitively.
+        $this->assertTrue($this->request->hasHeader('CUSTOM'));
+        $this->assertFalse($this->request->hasHeader('missing'));
+
+        // Missing headers fall back to the provided default.
+        $this->assertSame([], $this->request->getHeader('missing'));
+        $this->assertSame('fallback', $this->request->getHeaderLine('missing', 'fallback'));
 
         $headers = $this->request->getHeaders();
         $this->assertCount(2, $headers);
-        $this->assertSame('value1', $headers['custom']);
-        $this->assertSame('value2', $headers['custom-new']);
+        $this->assertSame(['value1'], $headers['custom']);
+        $this->assertSame(['value2'], $headers['custom-new']);
     }
 
     public function testCanAddHeaders(): void
@@ -40,8 +63,17 @@ final class RequestTest extends TestCase
         $this->request->addHeader('custom', 'value1');
         $this->request->addHeader('custom-new', 'value2');
 
-        $this->assertSame('value1', $this->request->getHeader('custom'));
-        $this->assertSame('value2', $this->request->getHeader('custom-new'));
+        $this->assertSame(['value1'], $this->request->getHeader('custom'));
+        $this->assertSame(['value2'], $this->request->getHeader('custom-new'));
+
+        // addHeader appends additional values, mirroring PSR-7's withAddedHeader.
+        $this->request->addHeader('Custom', 'value3');
+        $this->assertSame(['value1', 'value3'], $this->request->getHeader('custom'));
+        $this->assertSame('value1, value3', $this->request->getHeaderLine('custom'));
+
+        // setHeader replaces all existing values, mirroring PSR-7's withHeader.
+        $this->request->setHeader('custom', 'only');
+        $this->assertSame(['only'], $this->request->getHeader('custom'));
     }
 
     public function testCanRemoveHeaders(): void
@@ -49,13 +81,14 @@ final class RequestTest extends TestCase
         $this->request->addHeader('custom', 'value1');
         $this->request->addHeader('custom-new', 'value2');
 
-        $this->assertSame('value1', $this->request->getHeader('custom'));
-        $this->assertSame('value2', $this->request->getHeader('custom-new'));
+        $this->assertSame(['value1'], $this->request->getHeader('custom'));
+        $this->assertSame(['value2'], $this->request->getHeader('custom-new'));
 
-        $this->request->removeHeader('custom');
+        $this->request->removeHeader('Custom');
 
-        $this->assertSame('', $this->request->getHeader('custom'));
-        $this->assertSame('value2', $this->request->getHeader('custom-new'));
+        $this->assertFalse($this->request->hasHeader('custom'));
+        $this->assertSame([], $this->request->getHeader('custom'));
+        $this->assertSame(['value2'], $this->request->getHeader('custom-new'));
     }
 
     public function testCanGetQueryParameter(): void
@@ -112,6 +145,23 @@ final class RequestTest extends TestCase
     {
         $_COOKIE['key'] = 'value';
 
+        $this->assertSame('value', $this->request->getCookie('key'));
+        $this->assertSame('test', $this->request->getCookie('unknown', 'test'));
+    }
+
+    public function testCanGetCookieParams(): void
+    {
+        $_COOKIE['key'] = 'value';
+        $_COOKIE['other'] = 'second';
+
+        $this->assertSame(['key' => 'value', 'other' => 'second'], $this->request->getCookieParams());
+    }
+
+    public function testCanSetCookieParams(): void
+    {
+        $this->request->setCookieParams(['key' => 'value']);
+
+        $this->assertSame(['key' => 'value'], $this->request->getCookieParams());
         $this->assertSame('value', $this->request->getCookie('key'));
         $this->assertSame('test', $this->request->getCookie('unknown', 'test'));
     }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -88,6 +88,22 @@ final class FPMResponseTest extends TestCase
         $this->assertSame('body', $html);
     }
 
+    public function testCanSendMinimalCookie(): void
+    {
+        ob_start(); //Start of build
+
+        // A cookie with only a name (null value, no SameSite/secure/etc.) must
+        // not trigger a TypeError when proxied to setcookie()/Swoole's cookie().
+        @$this->response
+            ->addCookie('name')
+            ->send('body');
+
+        $html = ob_get_contents();
+        ob_end_clean(); //End of build
+
+        $this->assertSame('body', $html);
+    }
+
     public function testCanSendRedirect(): void
     {
         ob_start(); //Start of build

--- a/tests/e2e/init.php
+++ b/tests/e2e/init.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once __DIR__ . '/../../vendor/autoload.php';
 
 use Utopia\Http\Http;
@@ -31,7 +33,7 @@ Http::get('/cookies')
     ->inject('request')
     ->inject('response')
     ->action(function (Request $request, Response $response) {
-        $response->send($request->getHeaders()['cookie'] ?? '');
+        $response->send($request->getHeaderLine('cookie'));
     });
 
 Http::get('/cookie/:key')


### PR DESCRIPTION
## Summary

Aligns the `Request` and `Response` header/cookie APIs with **PSR-7 semantics**, while keeping utopia's existing **mutable** style (methods mutate in place and return `$this`, rather than PSR-7's immutable `with*` instances).

**Headers**
- Header names are **case-insensitive** and stored **lowercased** internally.
- `getHeader()` now returns **all values as a list (`string[]`)** instead of a single joined `string`.
- New `getHeaderLine()` returns the comma-joined string (the old `getHeader()` behavior).
- New `hasHeader()` and `setHeader()` (replace-all, mirroring `withHeader`); `addHeader()` appends (mirroring `withAddedHeader`).
- `getHeaders()` returns `array<string, string[]>`.
- Header parsing/lookup is centralized in the base `Request`; adapters only supply the raw source via `generateHeaders()` / `generateCookies()`.

**Cookies**
- New `getCookieParams()` / `setCookieParams()` on `Request` (PSR-7's `getCookieParams`/`withCookieParams`), backed by a lazy `generateCookies()` per adapter. `getCookie()` reads through it.

**Correctness fixes uncovered while consulting [`swoole-src`](https://github.com/swoole/swoole-src)**
- **Multi-value headers on Swoole** must be passed as a single array in one `header()` call — Swoole's `set_header` uses `array_set` (overwrite), so per-value calls would silently drop all but the last value. The adapter now does this correctly.
- **Header-name casing is now consistent** across adapters: Swoole title-cases names on the wire (`set-cookie` → `Set-Cookie`); FPM now does the same, preserving utopia's prior `Content-Type`-style output.
- **Cookie hardening**: `null` SameSite/value are coalesced to typed defaults before being handed to Swoole's `cookie()` (`Z_PARAM_STR`) and PHP's `setcookie()`, avoiding reliance on weak-mode coercion / `TypeError`.

## Testing
- `phpstan` ✅ · `pint` ✅ · `rector` ✅
- Unit: **90/90** ✅
- E2E **FPM 8/8** ✅ and **Swoole 9/9** ✅ (run in the Docker containers exactly as CI does)
- Verified the raw wire output on both adapters — identical Title-Case header names and two separate `Set-Cookie` lines.

---

## ⚠️ Migration guide

These are **breaking changes** for consumers of `Utopia\Http\Request` and `Utopia\Http\Response`.

### 1. `getHeader()` now returns `string[]`, not `string`

`getHeader()` returns **all values** for a header. Use the new `getHeaderLine()` for the previous single-string behavior.

```php
// Before
$contentType = $request->getHeader('content-type', '');        // string
$auth        = $response->getHeaders()['authorization'] ?? ''; // string

// After
$contentType = $request->getHeaderLine('content-type', '');    // string  ← drop-in replacement
$values      = $request->getHeader('content-type');            // ['application/json']  (string[])
```

Rule of thumb: **every existing `getHeader(...)` call that expected a string should become `getHeaderLine(...)`.** The signatures match (`getHeaderLine(string $key, string $default = '')`), so it's a mechanical rename.

### 2. `getHeaders()` values are now `string[]`

```php
// Before
foreach ($request->getHeaders() as $name => $value) {
    echo "$name: $value";            // $value was a string (or sometimes array)
}

// After
foreach ($request->getHeaders() as $name => $values) {
    echo "$name: " . implode(', ', $values);   // $values is always string[]
}
```

### 3. Header names are lowercased and case-insensitive

`getHeaders()` keys are now always **lowercase**, and all lookups (`getHeader`, `getHeaderLine`, `hasHeader`, `removeHeader`) are case-insensitive.

```php
$request->getHeaders();              // ['content-type' => ['application/json'], ...]
$request->getHeader('Content-Type'); // same as getHeader('content-type')
```

If you previously indexed `getHeaders()` with a non-lowercase key (e.g. `getHeaders()['Content-Type']`), switch to `getHeader('Content-Type')` / `getHeaderLine('Content-Type')`.

### 4. `addHeader()` now strictly appends

`addHeader()` always **appends** a value (PSR-7 `withAddedHeader`). To **replace** all values for a header, use the new `setHeader()` (PSR-7 `withHeader`).

```php
// Replace
$response->setHeader('Cache-Control', 'no-cache');

// Append (e.g. multiple Set-Cookie)
$response->addHeader('Set-Cookie', 'a=1');
$response->addHeader('Set-Cookie', 'b=2');   // -> two Set-Cookie lines
```

### 5. Custom adapters: implement `generateCookies()` and updated signatures

If you maintain a custom `Request`/`Response` adapter:

- `Request`: the abstract `getHeader`/`addHeader`/`removeHeader`/`getCookie` are **gone** — they're now concrete in the base class. Implement the new abstract **`generateCookies(): array<string, string>`** (return cookie name => value). `generateHeaders()` (if you override it) must return **`array<string, string[]>`** with lowercased keys.
- `Response::sendHeader()` signature changed from `sendHeader(string $key, mixed $value)` to **`sendHeader(string $key, array $value)`** — `$value` is always `string[]`; emit one line per value.

### New APIs at a glance

| Concern | New method |
| --- | --- |
| All values of a header | `getHeader(string $key, array $default = []): string[]` |
| Joined header string | `getHeaderLine(string $key, string $default = ''): string` |
| Existence check | `hasHeader(string $key): bool` |
| Replace a header | `setHeader(string $key, string $value): static` |
| All request cookies | `getCookieParams(): array<string,string>` |
| Override request cookies | `setCookieParams(array $cookies): static` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
