### PR TITLE
Feat: support multiple methods per route via Http::routes()

### DIFF
--- a/Dockerfile.fpm
+++ b/Dockerfile.fpm
@@ -41,7 +41,7 @@ COPY --from=composer:2.7 /usr/bin/composer /usr/local/bin/composer
 COPY ./src /usr/share/nginx/html/src
 COPY ./tests /usr/share/nginx/html/tests
 COPY ./phpunit.xml /usr/share/nginx/html/phpunit.xml
-COPY ./composer.json ./composer.lock ./phpstan.neon ./pint.json /usr/share/nginx/html/
+COPY ./composer.json ./composer.lock ./phpstan.neon /usr/share/nginx/html/
 COPY --from=step0 /usr/local/src/vendor /usr/share/nginx/html/vendor
 
 # Supervisord Conf

--- a/Dockerfile.swoole
+++ b/Dockerfile.swoole
@@ -24,7 +24,7 @@ COPY --from=composer:2.7 /usr/bin/composer /usr/local/bin/composer
 COPY ./src /usr/src/code/src
 COPY ./tests /usr/src/code/tests
 COPY ./phpunit.xml /usr/src/code/phpunit.xml
-COPY ./composer.json ./composer.lock ./phpstan.neon ./pint.json /usr/src/code/
+COPY ./composer.json ./composer.lock ./phpstan.neon /usr/src/code/
 COPY --from=step0 /usr/local/src/vendor /usr/src/code/vendor
 
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Http::routes([Http::REQUEST_METHOD_GET, Http::REQUEST_METHOD_POST], '/oauth/user
     });
 ```
 
-Path aliases and multiple methods combine: a route with both responds on every method under every path. Note that `getMethod()` on the route returns the first method it was defined with; use the request resource to tell how a request arrived.
+Path aliases and multiple methods combine: a route with both responds on every method under every path. Use `getMethods()` to inspect the methods a route was registered with, and use the request resource to tell how a request arrived.
 
 ### Hooks
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,37 @@ curl http://localhost:8000/hello-world?name=Appwrite
 
 It's always recommended to use params instead of getting params or body directly from the request resource. If you do that intentionally, always make sure to run validation right after fetching such a raw input.
 
+### Aliases
+
+A route can be registered under additional paths and HTTP methods using aliases. All aliases dispatch to the same route, so the action, params, and hooks are defined only once.
+
+Use `alias()` to serve the same route under another path, for example to keep a legacy URL working:
+
+```php
+Http::get('/users/:id')
+    ->alias('/members/:id')
+    ->param('id', '', new Text(256), 'User ID')
+    ->inject('response')
+    ->action(function(string $id, Response $response) {
+        $response->json(['id' => $id]);
+    });
+```
+
+Use `aliasMethod()` to serve the same route under another HTTP method. For example, the OpenID Connect UserInfo endpoint must support both GET and POST:
+
+```php
+Http::get('/oauth/userinfo')
+    ->aliasMethod(Http::REQUEST_METHOD_POST)
+    ->inject('request')
+    ->inject('response')
+    ->action(function(Request $request, Response $response) {
+        // $request->getMethod() tells how the request arrived (GET or POST)
+        $response->json(['sub' => 'user-id']);
+    });
+```
+
+Path and method aliases combine: a route with both responds on every method under every path. Note that `getMethod()` on the route keeps returning the primary method it was defined with; use the request resource to tell how a request arrived.
+
 ### Hooks
 
 There are three types of hooks:

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ curl http://localhost:8000/hello-world?name=Appwrite
 
 It's always recommended to use params instead of getting params or body directly from the request resource. If you do that intentionally, always make sure to run validation right after fetching such a raw input.
 
-### Aliases and Multiple Methods
+### Multiple Methods
 
 A route can be registered under additional paths and multiple HTTP methods. All matching paths and methods dispatch to the same route, so the action, params, and hooks are defined only once.
 

--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ curl http://localhost:8000/hello-world?name=Appwrite
 
 It's always recommended to use params instead of getting params or body directly from the request resource. If you do that intentionally, always make sure to run validation right after fetching such a raw input.
 
-### Aliases
+### Aliases and Multiple Methods
 
-A route can be registered under additional paths and HTTP methods using aliases. All aliases dispatch to the same route, so the action, params, and hooks are defined only once.
+A route can be registered under additional paths and multiple HTTP methods. All matching paths and methods dispatch to the same route, so the action, params, and hooks are defined only once.
 
 Use `alias()` to serve the same route under another path, for example to keep a legacy URL working:
 
@@ -159,11 +159,10 @@ Http::get('/users/:id')
     });
 ```
 
-Use `aliasMethod()` to serve the same route under another HTTP method. For example, the OpenID Connect UserInfo endpoint must support both GET and POST:
+Use `routes()` to serve the same route under multiple HTTP methods. For example, the OpenID Connect UserInfo endpoint must support both GET and POST:
 
 ```php
-Http::get('/oauth/userinfo')
-    ->aliasMethod(Http::REQUEST_METHOD_POST)
+Http::routes([Http::REQUEST_METHOD_GET, Http::REQUEST_METHOD_POST], '/oauth/userinfo')
     ->inject('request')
     ->inject('response')
     ->action(function(Request $request, Response $response) {
@@ -172,7 +171,7 @@ Http::get('/oauth/userinfo')
     });
 ```
 
-Path and method aliases combine: a route with both responds on every method under every path. Note that `getMethod()` on the route keeps returning the primary method it was defined with; use the request resource to tell how a request arrived.
+Path aliases and multiple methods combine: a route with both responds on every method under every path. Note that `getMethod()` on the route returns the first method it was defined with; use the request resource to tell how a request arrived.
 
 ### Hooks
 

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -238,6 +238,14 @@ class Http
             throw new \Exception('At least one HTTP method is required.');
         }
 
+        $routes = Router::getRoutes();
+
+        foreach ($methods as $method) {
+            if (!\array_key_exists($method, $routes)) {
+                throw new \Exception("Method ({$method}) not supported.");
+            }
+        }
+
         $route = new Route($methods[0], $url, \array_slice($methods, 1));
         Router::addRoute($route);
 

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -246,7 +246,7 @@ class Http
             }
         }
 
-        $route = new Route($methods[0], $url, \array_slice($methods, 1));
+        $route = new Route($methods, $url);
         Router::addRoute($route);
 
         return $route;

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -179,7 +179,7 @@ class Http
      */
     public static function get(string $url): Route
     {
-        return self::addRoute(self::REQUEST_METHOD_GET, $url);
+        return self::routes(self::REQUEST_METHOD_GET, $url);
     }
 
     /**
@@ -189,7 +189,7 @@ class Http
      */
     public static function post(string $url): Route
     {
-        return self::addRoute(self::REQUEST_METHOD_POST, $url);
+        return self::routes(self::REQUEST_METHOD_POST, $url);
     }
 
     /**
@@ -199,7 +199,7 @@ class Http
      */
     public static function put(string $url): Route
     {
-        return self::addRoute(self::REQUEST_METHOD_PUT, $url);
+        return self::routes(self::REQUEST_METHOD_PUT, $url);
     }
 
     /**
@@ -209,7 +209,7 @@ class Http
      */
     public static function patch(string $url): Route
     {
-        return self::addRoute(self::REQUEST_METHOD_PATCH, $url);
+        return self::routes(self::REQUEST_METHOD_PATCH, $url);
     }
 
     /**
@@ -219,7 +219,29 @@ class Http
      */
     public static function delete(string $url): Route
     {
-        return self::addRoute(self::REQUEST_METHOD_DELETE, $url);
+        return self::routes(self::REQUEST_METHOD_DELETE, $url);
+    }
+
+    /**
+     * ROUTES
+     *
+     * Add one route under one or more request methods
+     *
+     * @param string|array<int, string> $methods
+     */
+    public static function routes(string|array $methods, string $url): Route
+    {
+        $methods = \is_array($methods) ? $methods : [$methods];
+        $methods = array_values(array_unique($methods));
+
+        if (empty($methods)) {
+            throw new \Exception('At least one HTTP method is required.');
+        }
+
+        $route = new Route($methods[0], $url, \array_slice($methods, 1));
+        Router::addRoute($route);
+
+        return $route;
     }
 
     /**

--- a/src/Http/Route.php
+++ b/src/Http/Route.php
@@ -81,13 +81,7 @@ class Route extends Hook
      */
     public function alias(string $path): self
     {
-        Router::validateRouteAlias($path, $this->methods);
-
         Router::addRouteAlias($path, $this);
-
-        foreach (\array_slice($this->methods, 1) as $method) {
-            Router::addRouteAlias($path, $this, $method);
-        }
 
         if (!\in_array($path, $this->aliasPaths, true)) {
             $this->aliasPaths[] = $path;

--- a/src/Http/Route.php
+++ b/src/Http/Route.php
@@ -89,7 +89,9 @@ class Route extends Hook
             Router::addRouteAlias($path, $this, $method);
         }
 
-        $this->aliasPaths[] = $path;
+        if (!\in_array($path, $this->aliasPaths, true)) {
+            $this->aliasPaths[] = $path;
+        }
 
         return $this;
     }
@@ -108,7 +110,9 @@ class Route extends Hook
             Router::addRouteAlias($path, $this, $method);
         }
 
-        $this->aliasMethods[] = $method;
+        if (!\in_array($method, $this->aliasMethods, true)) {
+            $this->aliasMethods[] = $method;
+        }
 
         return $this;
     }

--- a/src/Http/Route.php
+++ b/src/Http/Route.php
@@ -29,6 +29,20 @@ class Route extends Hook
     protected array $pathParams = [];
 
     /**
+     * Alias paths this route is also registered under.
+     *
+     * @var array<string>
+     */
+    protected array $aliasPaths = [];
+
+    /**
+     * Alias HTTP methods this route is also registered under.
+     *
+     * @var array<string>
+     */
+    protected array $aliasMethods = [];
+
+    /**
      * Internal counter.
      */
     protected static int $counter = 0;
@@ -71,6 +85,31 @@ class Route extends Hook
     {
         Router::addRouteAlias($path, $this);
 
+        foreach ($this->aliasMethods as $method) {
+            Router::addRouteAlias($path, $this, $method);
+        }
+
+        $this->aliasPaths[] = $path;
+
+        return $this;
+    }
+
+    /**
+     * Register this route under an additional HTTP method.
+     *
+     * The route keeps reporting its primary method via getMethod();
+     * use the request's method to tell how a request arrived.
+     */
+    public function aliasMethod(string $method): self
+    {
+        Router::addRouteMethodAlias($method, $this);
+
+        foreach ($this->aliasPaths as $path) {
+            Router::addRouteAlias($path, $this, $method);
+        }
+
+        $this->aliasMethods[] = $method;
+
         return $this;
     }
 
@@ -106,6 +145,26 @@ class Route extends Hook
     public function getHook(): bool
     {
         return $this->hook;
+    }
+
+    /**
+     * Get alias paths.
+     *
+     * @return array<string>
+     */
+    public function getAliasPaths(): array
+    {
+        return $this->aliasPaths;
+    }
+
+    /**
+     * Get alias methods.
+     *
+     * @return array<string>
+     */
+    public function getAliasMethods(): array
+    {
+        return $this->aliasMethods;
     }
 
     /**

--- a/src/Http/Route.php
+++ b/src/Http/Route.php
@@ -135,23 +135,13 @@ class Route extends Hook
     }
 
     /**
-     * Get alias paths.
+     * Get additional methods this route is registered under.
      *
      * @return array<string>
      */
-    public function getAliasPaths(): array
+    public function getAdditionalMethods(): array
     {
-        return $this->aliasPaths;
-    }
-
-    /**
-     * Get methods this route is registered under.
-     *
-     * @return array<string>
-     */
-    public function getMethods(): array
-    {
-        return array_merge([$this->method], $this->additionalMethods);
+        return $this->additionalMethods;
     }
 
     /**

--- a/src/Http/Route.php
+++ b/src/Http/Route.php
@@ -36,11 +36,11 @@ class Route extends Hook
     protected array $aliasPaths = [];
 
     /**
-     * Alias HTTP methods this route is also registered under.
+     * Additional HTTP methods this route is also registered under.
      *
      * @var array<string>
      */
-    protected array $aliasMethods = [];
+    protected array $additionalMethods = [];
 
     /**
      * Internal counter.
@@ -52,11 +52,15 @@ class Route extends Hook
      */
     protected int $order;
 
-    public function __construct(string $method, string $path)
+    /**
+     * @param array<int, string> $additionalMethods
+     */
+    public function __construct(string $method, string $path, array $additionalMethods = [])
     {
         parent::__construct();
         $this->path($path);
         $this->method = $method;
+        $this->additionalMethods = $additionalMethods;
         $this->order = ++self::$counter;
     }
 
@@ -85,33 +89,12 @@ class Route extends Hook
     {
         Router::addRouteAlias($path, $this);
 
-        foreach ($this->aliasMethods as $method) {
+        foreach ($this->additionalMethods as $method) {
             Router::addRouteAlias($path, $this, $method);
         }
 
         if (!\in_array($path, $this->aliasPaths, true)) {
             $this->aliasPaths[] = $path;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Register this route under an additional HTTP method.
-     *
-     * The route keeps reporting its primary method via getMethod();
-     * use the request's method to tell how a request arrived.
-     */
-    public function aliasMethod(string $method): self
-    {
-        Router::addRouteMethodAlias($method, $this);
-
-        foreach ($this->aliasPaths as $path) {
-            Router::addRouteAlias($path, $this, $method);
-        }
-
-        if (!\in_array($method, $this->aliasMethods, true)) {
-            $this->aliasMethods[] = $method;
         }
 
         return $this;
@@ -162,13 +145,13 @@ class Route extends Hook
     }
 
     /**
-     * Get alias methods.
+     * Get methods this route is registered under.
      *
      * @return array<string>
      */
-    public function getAliasMethods(): array
+    public function getMethods(): array
     {
-        return $this->aliasMethods;
+        return array_merge([$this->method], $this->additionalMethods);
     }
 
     /**

--- a/src/Http/Route.php
+++ b/src/Http/Route.php
@@ -7,9 +7,11 @@ use Utopia\Servers\Hook;
 class Route extends Hook
 {
     /**
-     * HTTP Method
+     * HTTP Methods
+     *
+     * @var array<string>
      */
-    protected string $method = '';
+    protected array $methods = [];
 
     /**
      * Whether to use hook
@@ -36,13 +38,6 @@ class Route extends Hook
     protected array $aliasPaths = [];
 
     /**
-     * Additional HTTP methods this route is also registered under.
-     *
-     * @var array<string>
-     */
-    protected array $additionalMethods = [];
-
-    /**
      * Internal counter.
      */
     protected static int $counter = 0;
@@ -53,14 +48,13 @@ class Route extends Hook
     protected int $order;
 
     /**
-     * @param array<int, string> $additionalMethods
+     * @param string|array<int, string> $methods
      */
-    public function __construct(string $method, string $path, array $additionalMethods = [])
+    public function __construct(string|array $methods, string $path)
     {
         parent::__construct();
         $this->path($path);
-        $this->method = $method;
-        $this->additionalMethods = $additionalMethods;
+        $this->methods = \is_array($methods) ? array_values(array_unique($methods)) : [$methods];
         $this->order = ++self::$counter;
     }
 
@@ -87,11 +81,11 @@ class Route extends Hook
      */
     public function alias(string $path): self
     {
-        Router::validateRouteAlias($path, [$this->method, ...$this->additionalMethods]);
+        Router::validateRouteAlias($path, $this->methods);
 
         Router::addRouteAlias($path, $this);
 
-        foreach ($this->additionalMethods as $method) {
+        foreach (\array_slice($this->methods, 1) as $method) {
             Router::addRouteAlias($path, $this, $method);
         }
 
@@ -113,11 +107,13 @@ class Route extends Hook
     }
 
     /**
-     * Get HTTP Method
+     * Get primary HTTP method.
+     *
+     * @deprecated Use getMethods() instead.
      */
     public function getMethod(): string
     {
-        return $this->method;
+        return $this->methods[0] ?? '';
     }
 
     /**
@@ -137,13 +133,13 @@ class Route extends Hook
     }
 
     /**
-     * Get additional methods this route is registered under.
+     * Get HTTP methods this route is registered under.
      *
      * @return array<string>
      */
-    public function getAdditionalMethods(): array
+    public function getMethods(): array
     {
-        return $this->additionalMethods;
+        return $this->methods;
     }
 
     /**

--- a/src/Http/Route.php
+++ b/src/Http/Route.php
@@ -87,6 +87,8 @@ class Route extends Hook
      */
     public function alias(string $path): self
     {
+        Router::validateRouteAlias($path, [$this->method, ...$this->additionalMethods]);
+
         Router::addRouteAlias($path, $this);
 
         foreach ($this->additionalMethods as $method) {

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -95,19 +95,53 @@ class Router
      *
      * @throws \Exception
      */
-    public static function addRouteAlias(string $path, Route $route): void
+    public static function addRouteAlias(string $path, Route $route, ?string $method = null): void
     {
+        $method ??= $route->getMethod();
+
+        if (!\array_key_exists($method, self::$routes)) {
+            throw new Exception("Method ({$method}) not supported.");
+        }
+
         [$alias, $params] = self::preparePath($path);
 
-        if (\array_key_exists($alias, self::$routes[$route->getMethod()]) && !self::$allowOverride) {
-            throw new Exception("Route for ({$route->getMethod()}:{$alias}) already registered.");
+        if (\array_key_exists($alias, self::$routes[$method]) && !self::$allowOverride) {
+            throw new Exception("Route for ({$method}:{$alias}) already registered.");
         }
 
         foreach ($params as $key => $index) {
             $route->setPathParam($key, $index, $alias);
         }
 
-        self::$routes[$route->getMethod()][$alias] = $route;
+        self::$routes[$method][$alias] = $route;
+    }
+
+    /**
+     * Register a route under an additional HTTP method, using its own path.
+     *
+     * @throws \Exception
+     */
+    public static function addRouteMethodAlias(string $method, Route $route): void
+    {
+        if (!\array_key_exists($method, self::$routes)) {
+            throw new Exception("Method ({$method}) not supported.");
+        }
+
+        if ($route->getPath() === '') {
+            throw new Exception('Method aliases are not supported for the wildcard route.');
+        }
+
+        [$path, $params] = self::preparePath($route->getPath());
+
+        if (\array_key_exists($path, self::$routes[$method]) && !self::$allowOverride) {
+            throw new Exception("Route for ({$method}:{$path}) already registered.");
+        }
+
+        foreach ($params as $key => $index) {
+            $route->setPathParam($key, $index, $path);
+        }
+
+        self::$routes[$method][$path] = $route;
     }
 
     /**

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -74,26 +74,29 @@ class Router
     public static function addRoute(Route $route): void
     {
         [$path, $params] = self::preparePath($route->getPath());
+        $methods = $route->getMethods();
+        $method = $methods[0] ?? '';
+        $additionalMethods = \array_slice($methods, 1);
 
-        if (!\array_key_exists($route->getMethod(), self::$routes)) {
-            throw new Exception("Method ({$route->getMethod()}) not supported.");
+        if (!\array_key_exists($method, self::$routes)) {
+            throw new Exception("Method ({$method}) not supported.");
         }
 
-        if (\array_key_exists($path, self::$routes[$route->getMethod()]) && !self::$allowOverride) {
-            throw new Exception("Route for ({$route->getMethod()}:{$path}) already registered.");
+        if (\array_key_exists($path, self::$routes[$method]) && !self::$allowOverride) {
+            throw new Exception("Route for ({$method}:{$path}) already registered.");
         }
 
-        foreach ($route->getAdditionalMethods() as $method) {
-            if (!\array_key_exists($method, self::$routes)) {
-                throw new Exception("Method ({$method}) not supported.");
+        foreach ($additionalMethods as $additionalMethod) {
+            if (!\array_key_exists($additionalMethod, self::$routes)) {
+                throw new Exception("Method ({$additionalMethod}) not supported.");
             }
 
             if ($route->getPath() === '') {
                 throw new Exception('Additional route methods are not supported for the wildcard route.');
             }
 
-            if (\array_key_exists($path, self::$routes[$method]) && !self::$allowOverride) {
-                throw new Exception("Route for ({$method}:{$path}) already registered.");
+            if (\array_key_exists($path, self::$routes[$additionalMethod]) && !self::$allowOverride) {
+                throw new Exception("Route for ({$additionalMethod}:{$path}) already registered.");
             }
         }
 
@@ -101,10 +104,10 @@ class Router
             $route->setPathParam($key, $index, $path);
         }
 
-        self::$routes[$route->getMethod()][$path] = $route;
+        self::$routes[$method][$path] = $route;
 
-        foreach ($route->getAdditionalMethods() as $method) {
-            self::$routes[$method][$path] = $route;
+        foreach ($additionalMethods as $additionalMethod) {
+            self::$routes[$additionalMethod][$path] = $route;
         }
     }
 
@@ -137,7 +140,7 @@ class Router
      */
     public static function addRouteAlias(string $path, Route $route, ?string $method = null): void
     {
-        $method ??= $route->getMethod();
+        $method ??= $route->getMethods()[0] ?? '';
 
         if (!\array_key_exists($method, self::$routes)) {
             throw new Exception("Method ({$method}) not supported.");

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -89,7 +89,7 @@ class Router
 
         self::$routes[$route->getMethod()][$path] = $route;
 
-        foreach (\array_slice($route->getMethods(), 1) as $method) {
+        foreach ($route->getAdditionalMethods() as $method) {
             self::addRouteMethod($method, $route);
         }
     }

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -83,12 +83,6 @@ class Router
             throw new Exception("Route for ({$route->getMethod()}:{$path}) already registered.");
         }
 
-        foreach ($params as $key => $index) {
-            $route->setPathParam($key, $index, $path);
-        }
-
-        self::$routes[$route->getMethod()][$path] = $route;
-
         foreach ($route->getAdditionalMethods() as $method) {
             if (!\array_key_exists($method, self::$routes)) {
                 throw new Exception("Method ({$method}) not supported.");
@@ -101,7 +95,15 @@ class Router
             if (\array_key_exists($path, self::$routes[$method]) && !self::$allowOverride) {
                 throw new Exception("Route for ({$method}:{$path}) already registered.");
             }
+        }
 
+        foreach ($params as $key => $index) {
+            $route->setPathParam($key, $index, $path);
+        }
+
+        self::$routes[$route->getMethod()][$path] = $route;
+
+        foreach ($route->getAdditionalMethods() as $method) {
             self::$routes[$method][$path] = $route;
         }
     }

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -90,7 +90,19 @@ class Router
         self::$routes[$route->getMethod()][$path] = $route;
 
         foreach ($route->getAdditionalMethods() as $method) {
-            self::addRouteMethod($method, $route);
+            if (!\array_key_exists($method, self::$routes)) {
+                throw new Exception("Method ({$method}) not supported.");
+            }
+
+            if ($route->getPath() === '') {
+                throw new Exception('Additional route methods are not supported for the wildcard route.');
+            }
+
+            if (\array_key_exists($path, self::$routes[$method]) && !self::$allowOverride) {
+                throw new Exception("Route for ({$method}:{$path}) already registered.");
+            }
+
+            self::$routes[$method][$path] = $route;
         }
     }
 
@@ -118,34 +130,6 @@ class Router
         }
 
         self::$routes[$method][$alias] = $route;
-    }
-
-    /**
-     * Register a route under an additional HTTP method, using its own path.
-     *
-     * @throws \Exception
-     */
-    public static function addRouteMethod(string $method, Route $route): void
-    {
-        if (!\array_key_exists($method, self::$routes)) {
-            throw new Exception("Method ({$method}) not supported.");
-        }
-
-        if ($route->getPath() === '') {
-            throw new Exception('Additional route methods are not supported for the wildcard route.');
-        }
-
-        [$path, $params] = self::preparePath($route->getPath());
-
-        if (\array_key_exists($path, self::$routes[$method]) && !self::$allowOverride) {
-            throw new Exception("Route for ({$method}:{$path}) already registered.");
-        }
-
-        foreach ($params as $key => $index) {
-            $route->setPathParam($key, $index, $path);
-        }
-
-        self::$routes[$method][$path] = $route;
     }
 
     /**

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -112,15 +112,14 @@ class Router
     }
 
     /**
-     * Validate that a route alias can be registered for every supplied method.
+     * Add route to router.
      *
-     * @param array<int, string> $methods
-     *
-     * @throws Exception
+     * @throws \Exception
      */
-    public static function validateRouteAlias(string $path, array $methods): void
+    public static function addRouteAlias(string $path, Route $route): void
     {
-        [$alias] = self::preparePath($path);
+        $methods = $route->getMethods();
+        [$alias, $params] = self::preparePath($path);
 
         foreach ($methods as $method) {
             if (!\array_key_exists($method, self::$routes)) {
@@ -131,32 +130,14 @@ class Router
                 throw new Exception("Route for ({$method}:{$alias}) already registered.");
             }
         }
-    }
-
-    /**
-     * Add route to router.
-     *
-     * @throws \Exception
-     */
-    public static function addRouteAlias(string $path, Route $route, ?string $method = null): void
-    {
-        $method ??= $route->getMethods()[0] ?? '';
-
-        if (!\array_key_exists($method, self::$routes)) {
-            throw new Exception("Method ({$method}) not supported.");
-        }
-
-        [$alias, $params] = self::preparePath($path);
-
-        if (\array_key_exists($alias, self::$routes[$method]) && !self::$allowOverride) {
-            throw new Exception("Route for ({$method}:{$alias}) already registered.");
-        }
 
         foreach ($params as $key => $index) {
             $route->setPathParam($key, $index, $alias);
         }
 
-        self::$routes[$method][$alias] = $route;
+        foreach ($methods as $method) {
+            self::$routes[$method][$alias] = $route;
+        }
     }
 
     /**

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -109,6 +109,28 @@ class Router
     }
 
     /**
+     * Validate that a route alias can be registered for every supplied method.
+     *
+     * @param array<int, string> $methods
+     *
+     * @throws Exception
+     */
+    public static function validateRouteAlias(string $path, array $methods): void
+    {
+        [$alias] = self::preparePath($path);
+
+        foreach ($methods as $method) {
+            if (!\array_key_exists($method, self::$routes)) {
+                throw new Exception("Method ({$method}) not supported.");
+            }
+
+            if (\array_key_exists($alias, self::$routes[$method]) && !self::$allowOverride) {
+                throw new Exception("Route for ({$method}:{$alias}) already registered.");
+            }
+        }
+    }
+
+    /**
      * Add route to router.
      *
      * @throws \Exception

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -88,6 +88,10 @@ class Router
         }
 
         self::$routes[$route->getMethod()][$path] = $route;
+
+        foreach (\array_slice($route->getMethods(), 1) as $method) {
+            self::addRouteMethod($method, $route);
+        }
     }
 
     /**
@@ -121,14 +125,14 @@ class Router
      *
      * @throws \Exception
      */
-    public static function addRouteMethodAlias(string $method, Route $route): void
+    public static function addRouteMethod(string $method, Route $route): void
     {
         if (!\array_key_exists($method, self::$routes)) {
             throw new Exception("Method ({$method}) not supported.");
         }
 
         if ($route->getPath() === '') {
-            throw new Exception('Method aliases are not supported for the wildcard route.');
+            throw new Exception('Additional route methods are not supported for the wildcard route.');
         }
 
         [$path, $params] = self::preparePath($route->getPath());

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -266,6 +266,7 @@ class Router
     {
         self::$params = [];
         self::$wildcard = null;
+        self::$allowOverride = false;
         self::$routes = [
             Http::REQUEST_METHOD_GET => [],
             Http::REQUEST_METHOD_POST => [],

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -250,12 +250,9 @@ final class HttpTest extends TestCase
         $this->assertSame('init-' . $resource . '-(init-homepage)-param-x*param-y-(shutdown-homepage)-shutdown', $result);
     }
 
-    public function testCanExecuteRouteWithMethodAlias(): void
+    public function testCanExecuteRouteWithMultipleMethods(): void
     {
-        $route = Http::get('/v1/oauth/userinfo');
-
-        $route
-            ->aliasMethod(Http::REQUEST_METHOD_POST)
+        Http::routes([Http::REQUEST_METHOD_GET, Http::REQUEST_METHOD_POST], '/v1/oauth/userinfo')
             ->inject('request')
             ->action(function ($request) {
                 echo 'userinfo:' . $request->getMethod();

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -250,6 +250,32 @@ final class HttpTest extends TestCase
         $this->assertSame('init-' . $resource . '-(init-homepage)-param-x*param-y-(shutdown-homepage)-shutdown', $result);
     }
 
+    public function testCanExecuteRouteWithMethodAlias(): void
+    {
+        $route = Http::get('/v1/oauth/userinfo');
+
+        $route
+            ->aliasMethod(Http::REQUEST_METHOD_POST)
+            ->inject('request')
+            ->action(function ($request) {
+                echo 'userinfo:' . $request->getMethod();
+            });
+
+        $_SERVER['REQUEST_URI'] = '/v1/oauth/userinfo';
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        ob_start();
+        $this->http->run(new Request(), new Response());
+        $result = ob_get_clean();
+        $this->assertSame('userinfo:GET', $result);
+
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        ob_start();
+        $this->http->run(new Request(), new Response());
+        $result = ob_get_clean();
+        $this->assertSame('userinfo:POST', $result);
+    }
+
     public function testCanAddAndExecuteHooks(): void
     {
         Http::setAllowOverride(true);

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -19,6 +19,7 @@ final class RouteTest extends TestCase
     public function testCanGetMethod(): void
     {
         $this->assertSame('GET', $this->route->getMethod());
+        $this->assertSame(['GET'], $this->route->getMethods());
     }
 
     public function testCanGetAndSetPath(): void

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -150,7 +150,7 @@ final class RouterTest extends TestCase
         $this->assertEquals($route, Router::match(Http::REQUEST_METHOD_POST, '/userinfo')?->route);
         $this->assertNull(Router::match(Http::REQUEST_METHOD_PUT, '/userinfo'));
 
-        $this->assertSame(Http::REQUEST_METHOD_GET, $route->getMethod());
+        $this->assertSame([Http::REQUEST_METHOD_GET, Http::REQUEST_METHOD_POST], $route->getMethods());
     }
 
     public function testCanMatchRouteWithStringMethod(): void

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -187,9 +187,20 @@ final class RouterTest extends TestCase
         $routePOST = new Route(Http::REQUEST_METHOD_POST, '/userinfo');
         Router::addRoute($routePOST);
 
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Route for (POST:userinfo) already registered.');
-        Http::routes([Http::REQUEST_METHOD_GET, Http::REQUEST_METHOD_POST], '/userinfo');
+        try {
+            Http::routes([Http::REQUEST_METHOD_GET, Http::REQUEST_METHOD_POST], '/userinfo');
+            $this->fail('Expected duplicate route exception.');
+        } catch (\Exception $exception) {
+            $this->assertSame('Route for (POST:userinfo) already registered.', $exception->getMessage());
+        }
+
+        $routes = Router::getRoutes();
+        $this->assertArrayNotHasKey('userinfo', $routes[Http::REQUEST_METHOD_GET]);
+
+        $routeGET = Http::routes(Http::REQUEST_METHOD_GET, '/userinfo');
+
+        $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/userinfo')?->route);
+        $this->assertEquals($routePOST, Router::match(Http::REQUEST_METHOD_POST, '/userinfo')?->route);
     }
 
     public function testCanOverrideRouteMethod(): void

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -142,27 +142,30 @@ final class RouterTest extends TestCase
         $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/register/lorem/ipsum')?->route);
     }
 
-    public function testCanMatchMethodAlias(): void
+    public function testCanMatchRouteWithMultipleMethods(): void
     {
-        $route = new Route(Http::REQUEST_METHOD_GET, '/userinfo');
-        $route->aliasMethod(Http::REQUEST_METHOD_POST);
-
-        Router::addRoute($route);
+        $route = Http::routes([Http::REQUEST_METHOD_GET, Http::REQUEST_METHOD_POST], '/userinfo');
 
         $this->assertEquals($route, Router::match(Http::REQUEST_METHOD_GET, '/userinfo')?->route);
         $this->assertEquals($route, Router::match(Http::REQUEST_METHOD_POST, '/userinfo')?->route);
         $this->assertNull(Router::match(Http::REQUEST_METHOD_PUT, '/userinfo'));
 
         $this->assertSame(Http::REQUEST_METHOD_GET, $route->getMethod());
-        $this->assertSame([Http::REQUEST_METHOD_POST], $route->getAliasMethods());
+        $this->assertSame([Http::REQUEST_METHOD_GET, Http::REQUEST_METHOD_POST], $route->getMethods());
     }
 
-    public function testCanMatchMethodAliasWithPlaceholder(): void
+    public function testCanMatchRouteWithStringMethod(): void
     {
-        $route = new Route(Http::REQUEST_METHOD_GET, '/users/:id');
-        $route->aliasMethod(Http::REQUEST_METHOD_POST);
+        $route = Http::routes(Http::REQUEST_METHOD_GET, '/userinfo');
 
-        Router::addRoute($route);
+        $this->assertEquals($route, Router::match(Http::REQUEST_METHOD_GET, '/userinfo')?->route);
+        $this->assertNull(Router::match(Http::REQUEST_METHOD_POST, '/userinfo'));
+        $this->assertSame([Http::REQUEST_METHOD_GET], $route->getMethods());
+    }
+
+    public function testCanMatchRouteWithMultipleMethodsAndPlaceholder(): void
+    {
+        $route = Http::routes([Http::REQUEST_METHOD_GET, Http::REQUEST_METHOD_POST], '/users/:id');
 
         $match = Router::match(Http::REQUEST_METHOD_POST, '/users/abc-123');
 
@@ -170,41 +173,28 @@ final class RouterTest extends TestCase
         $this->assertSame(['id' => 'abc-123'], $match?->params);
     }
 
-    public function testMethodAliasCrossesPathAliasesRegardlessOfOrder(): void
+    public function testRoutesCrossPathAliases(): void
     {
-        $routeA = new Route(Http::REQUEST_METHOD_GET, '/a');
-        $routeA
-            ->alias('/a-old')
-            ->aliasMethod(Http::REQUEST_METHOD_POST);
+        $route = Http::routes([Http::REQUEST_METHOD_GET, Http::REQUEST_METHOD_POST], '/a')
+            ->alias('/a-old');
 
-        Router::addRoute($routeA);
-
-        $routeB = new Route(Http::REQUEST_METHOD_GET, '/b');
-        $routeB
-            ->aliasMethod(Http::REQUEST_METHOD_POST)
-            ->alias('/b-old');
-
-        Router::addRoute($routeB);
-
-        $this->assertEquals($routeA, Router::match(Http::REQUEST_METHOD_POST, '/a')?->route);
-        $this->assertEquals($routeA, Router::match(Http::REQUEST_METHOD_POST, '/a-old')?->route);
-        $this->assertEquals($routeB, Router::match(Http::REQUEST_METHOD_POST, '/b')?->route);
-        $this->assertEquals($routeB, Router::match(Http::REQUEST_METHOD_POST, '/b-old')?->route);
+        $this->assertEquals($route, Router::match(Http::REQUEST_METHOD_GET, '/a')?->route);
+        $this->assertEquals($route, Router::match(Http::REQUEST_METHOD_POST, '/a')?->route);
+        $this->assertEquals($route, Router::match(Http::REQUEST_METHOD_GET, '/a-old')?->route);
+        $this->assertEquals($route, Router::match(Http::REQUEST_METHOD_POST, '/a-old')?->route);
     }
 
-    public function testCannotRegisterDuplicateMethodAlias(): void
+    public function testCannotRegisterDuplicateRouteMethod(): void
     {
         $routePOST = new Route(Http::REQUEST_METHOD_POST, '/userinfo');
         Router::addRoute($routePOST);
 
-        $routeGET = new Route(Http::REQUEST_METHOD_GET, '/userinfo');
-
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Route for (POST:userinfo) already registered.');
-        $routeGET->aliasMethod(Http::REQUEST_METHOD_POST);
+        Http::routes([Http::REQUEST_METHOD_GET, Http::REQUEST_METHOD_POST], '/userinfo');
     }
 
-    public function testCanOverrideMethodAlias(): void
+    public function testCanOverrideRouteMethod(): void
     {
         Router::setAllowOverride(true);
 
@@ -212,34 +202,31 @@ final class RouterTest extends TestCase
             $routePOST = new Route(Http::REQUEST_METHOD_POST, '/userinfo');
             Router::addRoute($routePOST);
 
-            $routeGET = new Route(Http::REQUEST_METHOD_GET, '/userinfo');
-            Router::addRoute($routeGET);
-            $routeGET->aliasMethod(Http::REQUEST_METHOD_POST);
-            $routeGET->aliasMethod(Http::REQUEST_METHOD_POST);
+            $routeGET = Http::routes([
+                Http::REQUEST_METHOD_GET,
+                Http::REQUEST_METHOD_POST,
+                Http::REQUEST_METHOD_POST,
+            ], '/userinfo');
 
             $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_POST, '/userinfo')?->route);
-            $this->assertSame([Http::REQUEST_METHOD_POST], $routeGET->getAliasMethods());
+            $this->assertSame([Http::REQUEST_METHOD_GET, Http::REQUEST_METHOD_POST], $routeGET->getMethods());
         } finally {
             Router::setAllowOverride(false);
         }
     }
 
-    public function testCannotRegisterMethodAliasForUnknownMethod(): void
+    public function testCannotRegisterRouteForUnknownMethod(): void
     {
-        $route = new Route(Http::REQUEST_METHOD_GET, '/userinfo');
-
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Method (TRACE) not supported.');
-        $route->aliasMethod('TRACE');
+        Http::routes([Http::REQUEST_METHOD_GET, 'TRACE'], '/userinfo');
     }
 
-    public function testCannotRegisterMethodAliasOnWildcardRoute(): void
+    public function testCannotRegisterRouteWithoutMethods(): void
     {
-        $route = new Route('', '');
-
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Method aliases are not supported for the wildcard route.');
-        $route->aliasMethod(Http::REQUEST_METHOD_POST);
+        $this->expectExceptionMessage('At least one HTTP method is required.');
+        Http::routes([], '/userinfo');
     }
 
     public function testCanMatchFilename(): void

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -151,7 +151,6 @@ final class RouterTest extends TestCase
         $this->assertNull(Router::match(Http::REQUEST_METHOD_PUT, '/userinfo'));
 
         $this->assertSame(Http::REQUEST_METHOD_GET, $route->getMethod());
-        $this->assertSame([Http::REQUEST_METHOD_GET, Http::REQUEST_METHOD_POST], $route->getMethods());
     }
 
     public function testCanMatchRouteWithStringMethod(): void
@@ -160,7 +159,6 @@ final class RouterTest extends TestCase
 
         $this->assertEquals($route, Router::match(Http::REQUEST_METHOD_GET, '/userinfo')?->route);
         $this->assertNull(Router::match(Http::REQUEST_METHOD_POST, '/userinfo'));
-        $this->assertSame([Http::REQUEST_METHOD_GET], $route->getMethods());
     }
 
     public function testCanMatchRouteWithMultipleMethodsAndPlaceholder(): void
@@ -209,7 +207,6 @@ final class RouterTest extends TestCase
             ], '/userinfo');
 
             $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_POST, '/userinfo')?->route);
-            $this->assertSame([Http::REQUEST_METHOD_GET, Http::REQUEST_METHOD_POST], $routeGET->getMethods());
         } finally {
             Router::setAllowOverride(false);
         }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -180,6 +180,19 @@ final class RouterTest extends TestCase
         $this->assertEquals($route, Router::match(Http::REQUEST_METHOD_POST, '/a')?->route);
         $this->assertEquals($route, Router::match(Http::REQUEST_METHOD_GET, '/a-old')?->route);
         $this->assertEquals($route, Router::match(Http::REQUEST_METHOD_POST, '/a-old')?->route);
+
+        $routePOST = Http::routes(Http::REQUEST_METHOD_POST, '/b')->alias('/b-old');
+        $routeGETPOST = Http::routes([Http::REQUEST_METHOD_GET, Http::REQUEST_METHOD_POST], '/c');
+
+        try {
+            $routeGETPOST->alias('/b-old');
+            $this->fail('Expected duplicate route alias exception.');
+        } catch (\Exception $exception) {
+            $this->assertSame('Route for (POST:b-old) already registered.', $exception->getMessage());
+        }
+
+        $this->assertNull(Router::match(Http::REQUEST_METHOD_GET, '/b-old'));
+        $this->assertEquals($routePOST, Router::match(Http::REQUEST_METHOD_POST, '/b-old')?->route);
     }
 
     public function testCannotRegisterDuplicateRouteMethod(): void

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -219,6 +219,24 @@ final class RouterTest extends TestCase
         Http::routes([Http::REQUEST_METHOD_GET, 'TRACE'], '/userinfo');
     }
 
+    public function testUnknownMethodDoesNotPartiallyRegisterRoute(): void
+    {
+        try {
+            Http::routes([Http::REQUEST_METHOD_GET, 'TRACE'], '/userinfo');
+            $this->fail('Expected unknown method exception.');
+        } catch (\Exception $exception) {
+            $this->assertSame('Method (TRACE) not supported.', $exception->getMessage());
+        }
+
+        $routes = Router::getRoutes();
+        $this->assertArrayNotHasKey('userinfo', $routes[Http::REQUEST_METHOD_GET]);
+
+        $route = Http::routes([Http::REQUEST_METHOD_GET, Http::REQUEST_METHOD_POST], '/userinfo');
+
+        $this->assertEquals($route, Router::match(Http::REQUEST_METHOD_GET, '/userinfo')?->route);
+        $this->assertEquals($route, Router::match(Http::REQUEST_METHOD_POST, '/userinfo')?->route);
+    }
+
     public function testCannotRegisterRouteWithoutMethods(): void
     {
         $this->expectException(\Exception::class);

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -8,6 +8,11 @@ use PHPUnit\Framework\TestCase;
 
 final class RouterTest extends TestCase
 {
+    public function setUp(): void
+    {
+        Router::setAllowOverride(false);
+    }
+
     public function tearDown(): void
     {
         Router::reset();
@@ -135,6 +140,104 @@ final class RouterTest extends TestCase
         $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/console/lorem/ipsum/dolor')?->route);
         $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/auth/lorem/ipsum')?->route);
         $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_GET, '/register/lorem/ipsum')?->route);
+    }
+
+    public function testCanMatchMethodAlias(): void
+    {
+        $route = new Route(Http::REQUEST_METHOD_GET, '/userinfo');
+        $route->aliasMethod(Http::REQUEST_METHOD_POST);
+
+        Router::addRoute($route);
+
+        $this->assertEquals($route, Router::match(Http::REQUEST_METHOD_GET, '/userinfo')?->route);
+        $this->assertEquals($route, Router::match(Http::REQUEST_METHOD_POST, '/userinfo')?->route);
+        $this->assertNull(Router::match(Http::REQUEST_METHOD_PUT, '/userinfo'));
+
+        $this->assertSame(Http::REQUEST_METHOD_GET, $route->getMethod());
+        $this->assertSame([Http::REQUEST_METHOD_POST], $route->getAliasMethods());
+    }
+
+    public function testCanMatchMethodAliasWithPlaceholder(): void
+    {
+        $route = new Route(Http::REQUEST_METHOD_GET, '/users/:id');
+        $route->aliasMethod(Http::REQUEST_METHOD_POST);
+
+        Router::addRoute($route);
+
+        $match = Router::match(Http::REQUEST_METHOD_POST, '/users/abc-123');
+
+        $this->assertEquals($route, $match?->route);
+        $this->assertSame(['id' => 'abc-123'], $match?->params);
+    }
+
+    public function testMethodAliasCrossesPathAliasesRegardlessOfOrder(): void
+    {
+        $routeA = new Route(Http::REQUEST_METHOD_GET, '/a');
+        $routeA
+            ->alias('/a-old')
+            ->aliasMethod(Http::REQUEST_METHOD_POST);
+
+        Router::addRoute($routeA);
+
+        $routeB = new Route(Http::REQUEST_METHOD_GET, '/b');
+        $routeB
+            ->aliasMethod(Http::REQUEST_METHOD_POST)
+            ->alias('/b-old');
+
+        Router::addRoute($routeB);
+
+        $this->assertEquals($routeA, Router::match(Http::REQUEST_METHOD_POST, '/a')?->route);
+        $this->assertEquals($routeA, Router::match(Http::REQUEST_METHOD_POST, '/a-old')?->route);
+        $this->assertEquals($routeB, Router::match(Http::REQUEST_METHOD_POST, '/b')?->route);
+        $this->assertEquals($routeB, Router::match(Http::REQUEST_METHOD_POST, '/b-old')?->route);
+    }
+
+    public function testCannotRegisterDuplicateMethodAlias(): void
+    {
+        $routePOST = new Route(Http::REQUEST_METHOD_POST, '/userinfo');
+        Router::addRoute($routePOST);
+
+        $routeGET = new Route(Http::REQUEST_METHOD_GET, '/userinfo');
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Route for (POST:userinfo) already registered.');
+        $routeGET->aliasMethod(Http::REQUEST_METHOD_POST);
+    }
+
+    public function testCanOverrideMethodAlias(): void
+    {
+        Router::setAllowOverride(true);
+
+        try {
+            $routePOST = new Route(Http::REQUEST_METHOD_POST, '/userinfo');
+            Router::addRoute($routePOST);
+
+            $routeGET = new Route(Http::REQUEST_METHOD_GET, '/userinfo');
+            Router::addRoute($routeGET);
+            $routeGET->aliasMethod(Http::REQUEST_METHOD_POST);
+
+            $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_POST, '/userinfo')?->route);
+        } finally {
+            Router::setAllowOverride(false);
+        }
+    }
+
+    public function testCannotRegisterMethodAliasForUnknownMethod(): void
+    {
+        $route = new Route(Http::REQUEST_METHOD_GET, '/userinfo');
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Method (TRACE) not supported.');
+        $route->aliasMethod('TRACE');
+    }
+
+    public function testCannotRegisterMethodAliasOnWildcardRoute(): void
+    {
+        $route = new Route('', '');
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Method aliases are not supported for the wildcard route.');
+        $route->aliasMethod(Http::REQUEST_METHOD_POST);
     }
 
     public function testCanMatchFilename(): void

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -215,8 +215,10 @@ final class RouterTest extends TestCase
             $routeGET = new Route(Http::REQUEST_METHOD_GET, '/userinfo');
             Router::addRoute($routeGET);
             $routeGET->aliasMethod(Http::REQUEST_METHOD_POST);
+            $routeGET->aliasMethod(Http::REQUEST_METHOD_POST);
 
             $this->assertEquals($routeGET, Router::match(Http::REQUEST_METHOD_POST, '/userinfo')?->route);
+            $this->assertSame([Http::REQUEST_METHOD_POST], $routeGET->getAliasMethods());
         } finally {
             Router::setAllowOverride(false);
         }


### PR DESCRIPTION
## What does this PR do?

Adds `Http::routes()` so one route handler can be registered for multiple HTTP methods:

```php
Http::routes([Http::REQUEST_METHOD_GET, Http::REQUEST_METHOD_POST], '/oauth/userinfo')
    ->action(...);
```

This supports endpoints such as OpenID Connect UserInfo, where the same endpoint must accept both GET and POST, without duplicating route actions or adding another alias-specific public API.

### Implementation

- Adds `Http::routes(string|array $methods, string $url): Route`.
- Keeps `Http::get()`, `post()`, `put()`, `patch()`, and `delete()` as single-method wrappers around `routes()`.
- Stores route methods as one ordered array on `Route`; the first method remains the primary method for backwards compatibility.
- Adds `Route::getMethods()` for route metadata and keeps `Route::getMethod()` as a deprecated compatibility accessor.
- Registers every method in the router under the same path template and `Route` instance.
- Preserves path alias behavior so `Http::routes([GET, POST], '/new')->alias('/old')` matches both methods under both paths.
- Pre-validates method support, method path conflicts, and alias path conflicts before writing to the route table, preventing partial registrations when an exception is thrown.
- Keeps router override and duplicate-route semantics unchanged.

### Test plan

- [x] `vendor/bin/phpunit --configuration phpunit.xml tests/RouteTest.php tests/RouterTest.php tests/HttpTest.php`
- [x] `composer format:check`
- [x] `composer analyze`

Note: the full PHPUnit suite includes FPM/Swoole e2e tests that require `fpm` and `swoole` hosts; those were not available in the local shell environment.

## Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/http/blob/main/CONTRIBUTING.md)?

Yes