### PR TITLE
Implement the HTTP QUERY method (RFC 10008)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,27 @@ Http::routes([Http::REQUEST_METHOD_GET, Http::REQUEST_METHOD_POST], '/oauth/user
 
 Path aliases and multiple methods combine: a route with both responds on every method under every path. Use `getMethods()` to inspect the methods a route was registered with, and use the request resource to tell how a request arrived.
 
+### The QUERY Method
+
+The `QUERY` method ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)) is a safe, idempotent request method that carries the query as request content — useful when query parameters are too large or too sensitive for the URL. Register QUERY routes with `Http::query()`; the request body is parsed the same way as for POST, so JSON payloads map to params:
+
+```php
+Http::query('/documents/search')
+    ->param('filter', '', new Text(2048), 'Filter expression')
+    ->inject('response')
+    ->action(function(string $filter, Response $response) {
+        $response->json(['results' => []]);
+    });
+```
+
+Per the RFC, a QUERY request without a `Content-Type` header is rejected with a 400 error before the route action runs. To advertise the query formats a resource accepts, use `Response::setAcceptQuery()`, which serializes the `Accept-Query` header as an RFC 9651 structured field:
+
+```php
+$response->setAcceptQuery(['application/json', 'application/sql']);
+```
+
+Note: serving QUERY requires the underlying server to accept the method — PHP-FPM passes any method through, while Swoole support depends on the Swoole version's HTTP parser recognizing `QUERY`.
+
 ### Hooks
 
 There are three types of hooks:

--- a/src/Http/Adapter/FPM/Request.php
+++ b/src/Http/Adapter/FPM/Request.php
@@ -260,7 +260,8 @@ class Request extends UtopiaRequest
             self::METHOD_POST,
             self::METHOD_PUT,
             self::METHOD_PATCH,
-            self::METHOD_DELETE => $this->payload,
+            self::METHOD_DELETE,
+            self::METHOD_QUERY => $this->payload,
             default => $this->queryString,
         };
     }

--- a/src/Http/Adapter/Swoole/Request.php
+++ b/src/Http/Adapter/Swoole/Request.php
@@ -280,7 +280,8 @@ class Request extends UtopiaRequest
             self::METHOD_POST,
             self::METHOD_PUT,
             self::METHOD_PATCH,
-            self::METHOD_DELETE => $this->payload,
+            self::METHOD_DELETE,
+            self::METHOD_QUERY => $this->payload,
             default => $this->queryString,
         };
     }

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -29,6 +29,8 @@ class Http
 
     public const string REQUEST_METHOD_DELETE = 'DELETE';
 
+    public const string REQUEST_METHOD_QUERY = 'QUERY';
+
     public const string REQUEST_METHOD_OPTIONS = 'OPTIONS';
 
     public const string REQUEST_METHOD_HEAD = 'HEAD';
@@ -224,6 +226,18 @@ class Http
     public static function delete(string $url): Route
     {
         return self::routes(self::REQUEST_METHOD_DELETE, $url);
+    }
+
+    /**
+     * QUERY
+     *
+     * Add QUERY request route (RFC 10008). QUERY is a safe, idempotent
+     * method whose request content describes the query to evaluate against
+     * the target resource.
+     */
+    public static function query(string $url): Route
+    {
+        return self::routes(self::REQUEST_METHOD_QUERY, $url);
     }
 
     /**
@@ -626,6 +640,12 @@ class Http
         $groups = $route->getGroups();
 
         try {
+            // RFC 10008 Section 2: servers MUST fail a QUERY request whose
+            // Content-Type field is missing.
+            if (self::REQUEST_METHOD_QUERY === $method && $request->getHeaderLine('content-type') === '') {
+                throw new Exception('Content-Type header is required for QUERY requests', 400);
+            }
+
             if ($route->getHook()) {
                 foreach (self::$init as $hook) { // Global init hooks
                     if (\in_array('*', $hook->getGroups())) {

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -21,6 +21,8 @@ abstract class Request
 
     public const string METHOD_DELETE = 'DELETE';
 
+    public const string METHOD_QUERY = 'QUERY';
+
     public const string METHOD_TRACE = 'TRACE';
 
     public const string METHOD_CONNECT = 'CONNECT';

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -466,6 +466,25 @@ abstract class Response
     }
 
     /**
+     * Set Accept-Query header
+     *
+     * Advertise the media types accepted as QUERY request content (RFC 10008
+     * Section 3). Media types are serialized as an RFC 9651 Structured Field
+     * list of strings, e.g. `Accept-Query: "application/sql", "application/jsonpath"`.
+     *
+     * @param  array<int, string>  $mediaTypes
+     */
+    public function setAcceptQuery(array $mediaTypes): static
+    {
+        $items = array_map(
+            fn(string $type) => '"' . addcslashes($type, '"\\') . '"',
+            $mediaTypes,
+        );
+
+        return $this->setHeader('Accept-Query', implode(', ', $items));
+    }
+
+    /**
      * Remove header
      *
      * Remove an HTTP response header by its case-insensitive name.

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -28,6 +28,7 @@ class Router
         Http::REQUEST_METHOD_PUT => [],
         Http::REQUEST_METHOD_PATCH => [],
         Http::REQUEST_METHOD_DELETE => [],
+        Http::REQUEST_METHOD_QUERY => [],
     ];
 
     /**
@@ -269,6 +270,7 @@ class Router
             Http::REQUEST_METHOD_PUT => [],
             Http::REQUEST_METHOD_PATCH => [],
             Http::REQUEST_METHOD_DELETE => [],
+            Http::REQUEST_METHOD_QUERY => [],
         ];
     }
 }

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -250,6 +250,52 @@ final class HttpTest extends TestCase
         $this->assertSame('init-' . $resource . '-(init-homepage)-param-x*param-y-(shutdown-homepage)-shutdown', $result);
     }
 
+    public function testCanExecuteQueryRoute(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'QUERY';
+        $_SERVER['REQUEST_URI'] = '/search';
+
+        Http::query('/search')
+            ->param('q', '', new Text(200), 'query expression', true)
+            ->action(function ($q) {
+                echo 'results:' . $q;
+            });
+
+        $request = new Request();
+        $request->setHeader('content-type', 'application/json');
+        $request->setPayload(['q' => 'find-me']);
+
+        ob_start();
+        $this->http->execute($request, new Response());
+        $result = ob_get_clean();
+
+        $this->assertSame('results:find-me', $result);
+    }
+
+    public function testQueryRouteRequiresContentType(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'QUERY';
+        $_SERVER['REQUEST_URI'] = '/search';
+        unset($_SERVER['HTTP_CONTENT_TYPE'], $_SERVER['CONTENT_TYPE']);
+
+        $this->http
+            ->error()
+            ->inject('error')
+            ->action(function ($error) {
+                echo 'error-' . $error->getCode() . ':' . $error->getMessage();
+            });
+
+        Http::query('/search')->action(function () {
+            echo 'should-not-run';
+        });
+
+        ob_start();
+        $this->http->execute(new Request(), new Response());
+        $result = ob_get_clean();
+
+        $this->assertSame('error-400:Content-Type header is required for QUERY requests', $result);
+    }
+
     public function testCanExecuteRouteWithMultipleMethods(): void
     {
         Http::routes([Http::REQUEST_METHOD_GET, Http::REQUEST_METHOD_POST], '/v1/oauth/userinfo')

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -120,6 +120,17 @@ final class RequestTest extends TestCase
         $this->assertSame('test', $this->request->getPayload('unknown', 'test'));
     }
 
+    public function testQueryMethodParamsComeFromPayload(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'QUERY';
+        $_GET['ignored'] = 'query-string-value';
+
+        $this->request->setPayload(['q' => 'find-me']);
+
+        $this->assertSame(['q' => 'find-me'], $this->request->getParams());
+        $this->assertSame('find-me', $this->request->getParam('q'));
+    }
+
     public function testCanGetRawPayload(): void
     {
         $this->assertSame('', $this->request->getRawPayload());

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -29,6 +29,16 @@ final class FPMResponseTest extends TestCase
         $this->assertInstanceOf('Utopia\Http\Response', $contentType);
     }
 
+    public function testCanSetAcceptQuery(): void
+    {
+        $this->response->setAcceptQuery(['application/sql', 'application/jsonpath']);
+
+        $this->assertSame(
+            '"application/sql", "application/jsonpath"',
+            $this->response->getHeaderLine('Accept-Query'),
+        );
+    }
+
     public function testCanSetStatus(): void
     {
         $status = $this->response->setStatusCode(Response::STATUS_CODE_OK);

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -33,6 +33,16 @@ final class RouterTest extends TestCase
         $this->assertEquals($routeAboutMe, Router::match(Http::REQUEST_METHOD_GET, '/about/me')?->route);
     }
 
+    public function testCanMatchQueryMethod(): void
+    {
+        $routeSearch = new Route(Http::REQUEST_METHOD_QUERY, '/documents/search');
+
+        Router::addRoute($routeSearch);
+
+        $this->assertEquals($routeSearch, Router::match(Http::REQUEST_METHOD_QUERY, '/documents/search')?->route);
+        $this->assertNull(Router::match(Http::REQUEST_METHOD_GET, '/documents/search'));
+    }
+
     public function testCanMatchUrlWithPlaceholder(): void
     {
         $routeBlog = new Route(Http::REQUEST_METHOD_GET, '/blog');


### PR DESCRIPTION
## What does this PR do?

Implements [RFC 10008 — The HTTP QUERY Method](https://www.rfc-editor.org/rfc/rfc10008) (Standards Track, June 2026): a safe, idempotent HTTP method that carries the query as request content, for queries too large or too sensitive to encode in the URL.

### Changes

- **Routing**: `Http::REQUEST_METHOD_QUERY` / `Request::METHOD_QUERY` constants, a `QUERY` bucket in `Router` (including `reset()`), and a `Http::query('/path')` shortcut alongside `get()`/`post()`/etc. Composes with `Http::routes([...])` for multi-method routes.
- **Request content**: QUERY joins the body-carrying methods in `generateInput()` for the FPM and Swoole adapters (SwooleCoroutine inherits), so a JSON QUERY body maps to route params exactly like POST.
- **RFC MUST enforcement** (§2): a QUERY request without a `Content-Type` header is rejected with a 400 through the normal error-hook pipeline before the route action runs.
- **Discovery header** (§3): `Response::setAcceptQuery([...])` emits the `Accept-Query` field serialized as an RFC 9651 structured-field list of strings.
- **Docs**: new "The QUERY Method" README section with a usage example.

### Example

```php
Http::query('/documents/search')
    ->param('filter', '', new Text(2048), 'Filter expression')
    ->inject('response')
    ->action(function(string $filter, Response $response) {
        $response->json(['results' => []]);
    });
```

```http
QUERY /documents/search HTTP/1.1
Content-Type: application/json

{"filter": "status = 'active'"}
```

### Out of scope

The RFC's caching rules (cache keys incorporating request content, normalization) and conditional-request semantics apply to caches; this library has no cache layer, so there is nothing to implement there.

### Notes

- Serving QUERY requires the underlying server to accept the method: PHP-FPM passes any method through, while Swoole support depends on the Swoole version's HTTP parser recognizing `QUERY`. Worth verifying in the e2e/docker setup.

## Test Plan

7 new tests: `HttpTest` (dispatch + 400 on missing Content-Type), `RouterTest` (QUERY matching isolated from GET), `RequestTest` (params come from the payload for QUERY), `ResponseTest` (Accept-Query serialization). Full unit suite green locally except 3 pre-existing `ModeTest` errors (missing `Utopia\System\System` in the local env, fails on a clean checkout too).

## Related PRs and Issues

None.